### PR TITLE
Version 3.1.3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+#### v3.1.3
+
+* `[req]` `RequestTimeout` set to 0 (_disabled_) by default
+
 #### v3.1.2
 
 * `[terminal]` Fixed bug with source name file conventions

--- a/req/req.go
+++ b/req/req.go
@@ -86,7 +86,7 @@ var (
 	DialTimeout = 10.0
 
 	// RequestTimeout is request timeout in seconds
-	RequestTimeout = 5.0
+	RequestTimeout = 0.0
 
 	// Dialer default dialer struct
 	Dialer *net.Dialer
@@ -240,8 +240,10 @@ func (e RequestError) Error() string {
 
 func initTransport() {
 	if Dialer == nil {
-		Dialer = &net.Dialer{
-			Timeout: time.Duration(DialTimeout * float64(time.Second)),
+		Dialer = &net.Dialer{}
+
+		if DialTimeout > 0 {
+			Dialer.Timeout = time.Duration(DialTimeout * float64(time.Second))
 		}
 	}
 
@@ -255,7 +257,10 @@ func initTransport() {
 	if Client == nil {
 		Client = &http.Client{
 			Transport: Transport,
-			Timeout:   time.Duration(RequestTimeout * float64(time.Second)),
+		}
+
+		if RequestTimeout > 0 {
+			Client.Timeout = time.Duration(RequestTimeout * float64(time.Second))
 		}
 	}
 }

--- a/req/req_test.go
+++ b/req/req_test.go
@@ -82,6 +82,9 @@ func (s *ReqSuite) SetUpSuite(c *C) {
 
 	go runHTTPServer(s, c)
 
+	DialTimeout = 60.0
+	RequestTimeout = 60.0
+
 	time.Sleep(time.Second)
 }
 


### PR DESCRIPTION
#### Bugfixes
* `[req]` `RequestTimeout` set to 0 (_disabled_) by default