### PR TITLE
Version 3.2.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 ## Changelog
 
+#### v3.1.4
+
+* `[strutil]` Added method `Len` which return number of symbols in string
+* `[strutil]` UTF-8 support for `Substr`, `Tail`, `Head` and `Elipsis` methods
+* `[strutil]` Added some benchmarks to tests
+* `[fsutil]` Fixed `GetPerm` stub for Windows
+* `[fsutil]` Fixed package description
+
 #### v3.1.3
 
 * `[req]` `RequestTimeout` set to 0 (_disabled_) by default

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-#### v3.1.4
+#### v3.2.0
 
 * `[strutil]` Added method `Len` which return number of symbols in string
 * `[strutil]` UTF-8 support for `Substr`, `Tail`, `Head` and `Elipsis` methods

--- a/fsutil/fs.go
+++ b/fsutil/fs.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-// Package fsutil provides methods for working with files in posix compatible systems
+// Package fsutil provides methods for working with files on posix compatible systems
 package fsutil
 
 // ////////////////////////////////////////////////////////////////////////////////// //

--- a/fsutil/fs_windows.go
+++ b/fsutil/fs_windows.go
@@ -120,7 +120,7 @@ func GetSize(path string) int64 {
 	return 0
 }
 
-func GetPerm() os.FileMode {
+func GetPerm(path string) os.FileMode {
 	return 0644
 }
 

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ go get -u pkg.re/essentialkaos/ek.v3
 * [`errutil`](https://godoc.org/pkg.re/essentialkaos/ek.v3/errutil) - Package provides methods for working with errors
 * [`fmtc`](https://godoc.org/pkg.re/essentialkaos/ek.v3/fmtc) - Package provides methods similar to fmt for colored output
 * [`fmtutil`](https://godoc.org/pkg.re/essentialkaos/ek.v3/fmtutil) - Package provides methods for output formating
-* [`fsutil`](https://godoc.org/pkg.re/essentialkaos/ek.v3/fsutil) - Package provides methods for working with files in posix compatible systems (Linux / Mac OS X)
+* [`fsutil`](https://godoc.org/pkg.re/essentialkaos/ek.v3/fsutil) - Package provides methods for working with files on posix compatible systems (Linux / Mac OS X)
 * [`httputil`](https://godoc.org/pkg.re/essentialkaos/ek.v3/httputil) - Package provides methods for working with http request/responses
 * [`jsonutil`](https://godoc.org/pkg.re/essentialkaos/ek.v3/jsonutil) - Package provides methods for working with json data
 * [`knf`](https://godoc.org/pkg.re/essentialkaos/ek.v3/knf) - Package provides methods for working with configs in KNF format

--- a/strutil/strutil.go
+++ b/strutil/strutil.go
@@ -32,54 +32,53 @@ func Substr(s string, start int, end int) string {
 		return ""
 	}
 
-	sl := len(s)
+	var count int
+	var startIndex int
 
-	if start > sl {
+	for i := range s {
+		if count == start {
+			startIndex = i
+		}
+
+		if count == end {
+			return s[startIndex:i]
+		}
+
+		count++
+	}
+
+	switch {
+	case count < start:
 		return ""
+	case startIndex != 0:
+		return s[startIndex:]
 	}
 
-	if start < 0 {
-		start = 0
+	return s
+}
+
+// Len return number of symbols in string
+func Len(s string) int {
+	if s == "" {
+		return 0
 	}
 
-	if end > sl || end == 0 {
-		end = sl
+	var count int
+
+	for range s {
+		count++
 	}
 
-	input := bytes.NewBufferString(s)
-	output := bytes.NewBufferString("")
-
-	input.Next(start)
-
-	current := 0
-	max := end - start
-
-	for {
-		r, _, _ := input.ReadRune()
-
-		if r == rune(65533) {
-			continue
-		}
-
-		output.WriteRune(r)
-
-		current++
-
-		if current == max {
-			break
-		}
-	}
-
-	return output.String()
+	return count
 }
 
 // Ellipsis trims given string
 func Ellipsis(s string, maxSize int) string {
-	if len([]rune(s)) > maxSize {
-		return Substr(s, 0, maxSize-3) + "..."
+	if Len(s) <= maxSize {
+		return s
 	}
 
-	return s
+	return Substr(s, 0, maxSize-3) + "..."
 }
 
 // Head return n first symbols from given string
@@ -88,13 +87,13 @@ func Head(s string, n int) string {
 		return ""
 	}
 
-	l := len(s)
+	l := Len(s)
 
 	if l <= n {
 		return s
 	}
 
-	return s[:n]
+	return Substr(s, 0, n)
 }
 
 // Tail return n last symbols from given string
@@ -103,13 +102,14 @@ func Tail(s string, n int) string {
 		return ""
 	}
 
-	l := len(s)
+	l := Len(s)
 
 	if l <= n {
 		return s
 	}
 
 	return s[l-n:]
+	return Substr(s, l-n, 99999999999)
 }
 
 // PrefixSize return prefix size

--- a/strutil/strutil_test.go
+++ b/strutil/strutil_test.go
@@ -38,16 +38,27 @@ func (s *StrUtilSuite) TestSubstr(c *C) {
 	c.Assert(Substr("", 1, 2), Equals, "")
 	c.Assert(Substr("test1234TEST", 30, 32), Equals, "")
 	c.Assert(Substr("test1234TEST", 0, 8), Equals, "test1234")
+	c.Assert(Substr("test1234TEST", 0, 999), Equals, "test1234TEST")
 	c.Assert(Substr("test1234TEST", 4, 8), Equals, "1234")
 	c.Assert(Substr("test1234TEST", 8, 16), Equals, "TEST")
 	c.Assert(Substr("test1234TEST", -1, 4), Equals, "test")
+}
 
-	c.Assert(Substr("test"+string(rune(65533))+"1234TEST", 0, 8), Equals, "test1234")
+func (s *StrUtilSuite) BenchmarkSubstr(c *C) {
+	for i := 0; i < c.N; i++ {
+		Substr("test1234TEST", 4, 8)
+	}
 }
 
 func (s *StrUtilSuite) TestEllipsis(c *C) {
 	c.Assert(Ellipsis("Test1234", 8), Equals, "Test1234")
 	c.Assert(Ellipsis("Test1234test", 8), Equals, "Test1...")
+}
+
+func (s *StrUtilSuite) BenchmarkEllipsis(c *C) {
+	for i := 0; i < c.N; i++ {
+		Ellipsis("Test1234test", 8)
+	}
 }
 
 func (s *StrUtilSuite) TestHead(c *C) {
@@ -59,6 +70,12 @@ func (s *StrUtilSuite) TestHead(c *C) {
 	c.Assert(Head("ABCD1234", 100), Equals, "ABCD1234")
 }
 
+func (s *StrUtilSuite) BenchmarkHead(c *C) {
+	for i := 0; i < c.N; i++ {
+		Head("ABCD1234ABCD1234", 4)
+	}
+}
+
 func (s *StrUtilSuite) TestTail(c *C) {
 	c.Assert(Tail("", 1), Equals, "")
 	c.Assert(Tail("ABCD1234", 0), Equals, "")
@@ -66,6 +83,12 @@ func (s *StrUtilSuite) TestTail(c *C) {
 	c.Assert(Tail("ABCD1234", 1), Equals, "4")
 	c.Assert(Tail("ABCD1234", 4), Equals, "1234")
 	c.Assert(Tail("ABCD1234", 100), Equals, "ABCD1234")
+}
+
+func (s *StrUtilSuite) BenchmarkTail(c *C) {
+	for i := 0; i < c.N; i++ {
+		Tail("ABCD1234ABCD1234", 4)
+	}
 }
 
 func (s *StrUtilSuite) TestSize(c *C) {
@@ -80,6 +103,11 @@ func (s *StrUtilSuite) TestSize(c *C) {
 	c.Assert(SuffixSize("    ", ' '), Equals, 4)
 }
 
+func (s *StrUtilSuite) BenchmarkSize(c *C) {
+	for i := 0; i < c.N; i++ {
+		PrefixSize("    abcd", ' ')
+	}
+}
 func (s *StrUtilSuite) TestReplaceAll(c *C) {
 	c.Assert(ReplaceAll("ABCDABCD12341234", "AB12", "?"), Equals, "??CD??CD??34??34")
 	c.Assert(ReplaceAll("", "AB12", "?"), Equals, "")
@@ -93,4 +121,22 @@ func (s *StrUtilSuite) TestFields(c *C) {
 	c.Assert(Fields("1,  2, 3,   4, 5"), DeepEquals, []string{"1", "2", "3", "4", "5"})
 	c.Assert(Fields("\"1 2\" 3 \"4 5\""), DeepEquals, []string{"1 2", "3", "4 5"})
 	c.Assert(Fields("'1 2' 3 '4 5'"), DeepEquals, []string{"1 2", "3", "4 5"})
+}
+
+func (s *StrUtilSuite) BenchmarkFields(c *C) {
+	for i := 0; i < c.N; i++ {
+		Fields("\"1 2\" 3 \"4 5\"")
+	}
+}
+
+func (s *StrUtilSuite) TestLen(c *C) {
+	c.Assert(Len("ABCDABCD12341234"), Equals, 16)
+	c.Assert(Len(""), Equals, 0)
+	c.Assert(Len("✶✈12AB例例子예"), Equals, 10)
+}
+
+func (s *StrUtilSuite) BenchmarkLen(c *C) {
+	for i := 0; i < c.N; i++ {
+		Len("✶✈12AB例例子예")
+	}
 }


### PR DESCRIPTION
* `[strutil]` Added method `Len` which return number of symbols in string
* `[strutil]` UTF-8 support for `Substr`, `Tail`, `Head` and `Elipsis` methods
* `[strutil]` Added some benchmarks to tests
* `[fsutil]` Fixed `GetPerm` stub for Windows
* `[fsutil]` Fixed package description