### PR TITLE
Version 3.4.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+#### v3.4.2
+
+* `[strutil]` Fixed bug with overflowing int in `Tail` method
+
 #### v3.4.1
 
 * `[terminal]` Improved reading user input

--- a/strutil/strutil.go
+++ b/strutil/strutil.go
@@ -108,7 +108,7 @@ func Tail(s string, n int) string {
 		return s
 	}
 
-	return Substr(s, l-n, 99999999999)
+	return Substr(s, l-n, l)
 }
 
 // PrefixSize return prefix size


### PR DESCRIPTION
#### Bugfixes
* `[strutil]` Fixed bug with overflowing int in `Tail` method