### PR TITLE
Version 3.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 
 go:
   - 1.6.3
-  - tip
+  - 1.7.0
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 
 go:
   - 1.6.3
-  - tip
+  - 1.7
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 
 before_install:
   - go get -v pkg.re/check.v1
-  - go get -v pkg.re/essentialkaos/go-linenoise
+  - go get -v pkg.re/essentialkaos/go-linenoise.v2
 
 script:
   - .travis/script.sh .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 
 go:
-  - 1.5.4
-  - 1.6.2
+  - 1.6.3
   - tip
 
 sudo: false
@@ -16,7 +15,7 @@ env:
 
 before_install:
   - go get -v pkg.re/check.v1
-  - go get -v github.com/GeertJohan/go.linenoise
+  - go get -v pkg.re/essentialkaos/go-linenoise
 
 script:
   - .travis/script.sh .

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 
 go:
   - 1.6.3
-  - 1.7.0
+  - tip
 
 sudo: false
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ export EK_TEST_PORT=8080
 ########################################################################################
 
 deps:
-	go get -v github.com/GeertJohan/go.linenoise
+	go get -v pkg.re/essentialkaos/go-linenoise
 
 test:
 	go get -v pkg.re/check.v1

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ export EK_TEST_PORT=8080
 ########################################################################################
 
 deps:
-	go get -v pkg.re/essentialkaos/go-linenoise
+	go get -v pkg.re/essentialkaos/go-linenoise.v2
 
 test:
 	go get -v pkg.re/check.v1

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 * `[terminal]` Using forked [go.linenoise](https://github.com/essentialkaos/go-linenoise) package instead original
 * `[terminal]` Added hints support from new version of `go.linenoise`
+* `[fmtc]` Changed colors for `{s}` and `{S}` from light grey to dark grey
+* `[fmtc]` Light colors tag (`-`) support
 
 #### v3.4.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 * `[terminal]` Using forked [go.linenoise](https://github.com/essentialkaos/go-linenoise) package instead original
 * `[terminal]` Added hints support from new version of `go.linenoise`
 * `[fmtc]` Light colors tag (`-`) support
+* `[usage]` Using dark grey color for option values and example description
 
 #### v3.4.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+#### v3.5.0
+
+* `[terminal]` Using forked [go.linenoise](https://github.com/essentialkaos/go-linenoise) package instead original
+
 #### v3.4.2
 
 * `[strutil]` Fixed bug with overflowing int in `Tail` method

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 #### v3.5.0
 
 * `[terminal]` Using forked [go.linenoise](https://github.com/essentialkaos/go-linenoise) package instead original
+* `[terminal]` Added hints support from new version of `go.linenoise`
 
 #### v3.4.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,6 @@
 
 * `[terminal]` Using forked [go.linenoise](https://github.com/essentialkaos/go-linenoise) package instead original
 * `[terminal]` Added hints support from new version of `go.linenoise`
-* `[fmtc]` Changed colors for `{s}` and `{S}` from light grey to dark grey
 * `[fmtc]` Light colors tag (`-`) support
 
 #### v3.4.2

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 * `[terminal]` Added hints support from new version of `go.linenoise`
 * `[fmtc]` Light colors tag (`-`) support
 * `[usage]` Using dark grey color for option values and example description
+* `[tmp]` Added `DefaultDirPerms` and `DefaultFilePerms` global variables for permissions customization
 
 #### v3.4.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * `[fmtc]` Light colors tag (`-`) support
 * `[usage]` Using dark grey color for option values and example description
 * `[tmp]` Added `DefaultDirPerms` and `DefaultFilePerms` global variables for permissions customization
+* `[tmp]` Improved error handling
 
 #### v3.4.2
 

--- a/fmtc/fmtc.go
+++ b/fmtc/fmtc.go
@@ -34,12 +34,13 @@ type T struct {
 
 var codes = map[int]int{
 	// Special
-	'!': 0, // Default
-	'*': 1, // Bold
-	'^': 2, // Dim
-	'_': 4, // Underline
-	'~': 5, // Blink
-	'@': 7, // Reverse
+	'-': -1, // Light colors
+	'!': 0,  // Default
+	'*': 1,  // Bold
+	'^': 2,  // Dim
+	'_': 4,  // Underline
+	'~': 5,  // Blink
+	'@': 7,  // Reverse
 
 	// Text
 	'd': 30, // Black (Dark)
@@ -49,7 +50,7 @@ var codes = map[int]int{
 	'b': 34, // Blue
 	'm': 35, // Magenta
 	'c': 36, // Cyan
-	's': 37, // Grey (Smokey)
+	's': 90, // Grey (Smokey)
 	'w': 97, // White
 
 	// Background
@@ -60,13 +61,13 @@ var codes = map[int]int{
 	'B': 44,  // Blue
 	'M': 45,  // Magenta
 	'C': 46,  // Cyan
-	'S': 47,  // Grey (Smokey)
+	'S': 100, // Grey (Smokey)
 	'W': 107, // White
 }
 
 // ////////////////////////////////////////////////////////////////////////////////// //
 
-// DisableColors disable colors in output
+// DisableColors disable all colors and modificators in output
 var DisableColors = false
 
 // ////////////////////////////////////////////////////////////////////////////////// //
@@ -176,20 +177,34 @@ func tag2ANSI(tag string, clean bool) string {
 		modificator = 0
 		charColor   = 39
 		bgColor     = 49
+		light       = false
 	)
 
 	for _, key := range tag {
 		code, ok := codes[int(key)]
 
-		switch {
-		case !ok:
+		if !ok {
 			return fmt.Sprint(tag)
-		case code >= 1 && code <= 10:
+		}
+
+		switch key {
+		case '-':
+			light = true
+		case '!', '*', '^', '_', '~', '@':
 			modificator = code
-		case code >= 30 && code <= 40:
+		case 'd', 'r', 'g', 'y', 'b', 'm', 'c', 's', 'w':
 			charColor = code
-		case code >= 40 && code <= 50:
+		case 'D', 'R', 'G', 'Y', 'B', 'M', 'C', 'S', 'W':
 			bgColor = code
+		}
+	}
+
+	if light {
+		switch charColor {
+		case 90, 97:
+			break
+		default:
+			charColor += 60
 		}
 	}
 

--- a/fmtc/fmtc.go
+++ b/fmtc/fmtc.go
@@ -50,7 +50,7 @@ var codes = map[int]int{
 	'b': 34, // Blue
 	'm': 35, // Magenta
 	'c': 36, // Cyan
-	's': 90, // Grey (Smokey)
+	's': 37, // Grey (Smokey)
 	'w': 97, // White
 
 	// Background
@@ -61,7 +61,7 @@ var codes = map[int]int{
 	'B': 44,  // Blue
 	'M': 45,  // Magenta
 	'C': 46,  // Cyan
-	'S': 100, // Grey (Smokey)
+	'S': 47,  // Grey (Smokey)
 	'W': 107, // White
 }
 
@@ -201,8 +201,10 @@ func tag2ANSI(tag string, clean bool) string {
 
 	if light {
 		switch charColor {
-		case 90, 97:
+		case 97:
 			break
+		case 37:
+			charColor = 90
 		default:
 			charColor += 60
 		}

--- a/fmtc/fmtc_test.go
+++ b/fmtc/fmtc_test.go
@@ -33,6 +33,7 @@ func (s *FormatSuite) TestColors(c *C) {
 	c.Assert(Sprint("{m}W{!}"), Equals, "\x1b[0;35;49mW\x1b[0m")
 	c.Assert(Sprint("{c}W{!}"), Equals, "\x1b[0;36;49mW\x1b[0m")
 	c.Assert(Sprint("{s}W{!}"), Equals, "\x1b[0;37;49mW\x1b[0m")
+	c.Assert(Sprint("{w}W{!}"), Equals, "\x1b[0;97;49mW\x1b[0m")
 	c.Assert(Sprint("{r-}W{!}"), Equals, "\x1b[0;91;49mW\x1b[0m")
 	c.Assert(Sprint("{g-}W{!}"), Equals, "\x1b[0;92;49mW\x1b[0m")
 	c.Assert(Sprint("{y-}W{!}"), Equals, "\x1b[0;93;49mW\x1b[0m")
@@ -40,6 +41,7 @@ func (s *FormatSuite) TestColors(c *C) {
 	c.Assert(Sprint("{m-}W{!}"), Equals, "\x1b[0;95;49mW\x1b[0m")
 	c.Assert(Sprint("{c-}W{!}"), Equals, "\x1b[0;96;49mW\x1b[0m")
 	c.Assert(Sprint("{s-}W{!}"), Equals, "\x1b[0;90;49mW\x1b[0m")
+	c.Assert(Sprint("{w-}W{!}"), Equals, "\x1b[0;97;49mW\x1b[0m")
 }
 
 func (s *FormatSuite) TestBackgrounds(c *C) {

--- a/fmtc/fmtc_test.go
+++ b/fmtc/fmtc_test.go
@@ -32,7 +32,14 @@ func (s *FormatSuite) TestColors(c *C) {
 	c.Assert(Sprint("{b}W{!}"), Equals, "\x1b[0;34;49mW\x1b[0m")
 	c.Assert(Sprint("{m}W{!}"), Equals, "\x1b[0;35;49mW\x1b[0m")
 	c.Assert(Sprint("{c}W{!}"), Equals, "\x1b[0;36;49mW\x1b[0m")
-	c.Assert(Sprint("{s}W{!}"), Equals, "\x1b[0;37;49mW\x1b[0m")
+	c.Assert(Sprint("{s}W{!}"), Equals, "\x1b[0;90;49mW\x1b[0m")
+	c.Assert(Sprint("{r-}W{!}"), Equals, "\x1b[0;91;49mW\x1b[0m")
+	c.Assert(Sprint("{g-}W{!}"), Equals, "\x1b[0;92;49mW\x1b[0m")
+	c.Assert(Sprint("{y-}W{!}"), Equals, "\x1b[0;93;49mW\x1b[0m")
+	c.Assert(Sprint("{b-}W{!}"), Equals, "\x1b[0;94;49mW\x1b[0m")
+	c.Assert(Sprint("{m-}W{!}"), Equals, "\x1b[0;95;49mW\x1b[0m")
+	c.Assert(Sprint("{c-}W{!}"), Equals, "\x1b[0;96;49mW\x1b[0m")
+	c.Assert(Sprint("{s-}W{!}"), Equals, "\x1b[0;90;49mW\x1b[0m")
 }
 
 func (s *FormatSuite) TestBackgrounds(c *C) {
@@ -42,7 +49,8 @@ func (s *FormatSuite) TestBackgrounds(c *C) {
 	c.Assert(Sprint("{B}W{!}"), Equals, "\x1b[0;39;44mW\x1b[0m")
 	c.Assert(Sprint("{M}W{!}"), Equals, "\x1b[0;39;45mW\x1b[0m")
 	c.Assert(Sprint("{C}W{!}"), Equals, "\x1b[0;39;46mW\x1b[0m")
-	c.Assert(Sprint("{S}W{!}"), Equals, "\x1b[0;39;47mW\x1b[0m")
+	c.Assert(Sprint("{S}W{!}"), Equals, "\x1b[0;39;100mW\x1b[0m")
+	c.Assert(Sprint("{W}W{!}"), Equals, "\x1b[0;39;107mW\x1b[0m")
 }
 
 func (s *FormatSuite) TestSpecial(c *C) {

--- a/fmtc/fmtc_test.go
+++ b/fmtc/fmtc_test.go
@@ -32,7 +32,7 @@ func (s *FormatSuite) TestColors(c *C) {
 	c.Assert(Sprint("{b}W{!}"), Equals, "\x1b[0;34;49mW\x1b[0m")
 	c.Assert(Sprint("{m}W{!}"), Equals, "\x1b[0;35;49mW\x1b[0m")
 	c.Assert(Sprint("{c}W{!}"), Equals, "\x1b[0;36;49mW\x1b[0m")
-	c.Assert(Sprint("{s}W{!}"), Equals, "\x1b[0;90;49mW\x1b[0m")
+	c.Assert(Sprint("{s}W{!}"), Equals, "\x1b[0;37;49mW\x1b[0m")
 	c.Assert(Sprint("{r-}W{!}"), Equals, "\x1b[0;91;49mW\x1b[0m")
 	c.Assert(Sprint("{g-}W{!}"), Equals, "\x1b[0;92;49mW\x1b[0m")
 	c.Assert(Sprint("{y-}W{!}"), Equals, "\x1b[0;93;49mW\x1b[0m")
@@ -49,7 +49,7 @@ func (s *FormatSuite) TestBackgrounds(c *C) {
 	c.Assert(Sprint("{B}W{!}"), Equals, "\x1b[0;39;44mW\x1b[0m")
 	c.Assert(Sprint("{M}W{!}"), Equals, "\x1b[0;39;45mW\x1b[0m")
 	c.Assert(Sprint("{C}W{!}"), Equals, "\x1b[0;39;46mW\x1b[0m")
-	c.Assert(Sprint("{S}W{!}"), Equals, "\x1b[0;39;100mW\x1b[0m")
+	c.Assert(Sprint("{S}W{!}"), Equals, "\x1b[0;39;47mW\x1b[0m")
 	c.Assert(Sprint("{W}W{!}"), Equals, "\x1b[0;39;107mW\x1b[0m")
 }
 

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,7 @@ go get -u pkg.re/essentialkaos/ek.v3
 |--------|----------|---------|
 | `master` | [![Build Status](https://travis-ci.org/essentialkaos/ek.svg?branch=master)](https://travis-ci.org/essentialkaos/ek) | [![codecov.io](https://codecov.io/github/essentialkaos/ek/coverage.svg?branch=master)](https://codecov.io/github/essentialkaos/ek?branch=master) |
 | `develop` | [![Build Status](https://travis-ci.org/essentialkaos/ek.svg?branch=develop)](https://travis-ci.org/essentialkaos/ek) | [![codecov.io](https://codecov.io/github/essentialkaos/ek/coverage.svg?branch=develop)](https://codecov.io/github/essentialkaos/ek?branch=develop) |
+| `tip` |  [![Build Status](https://travis-ci.org/essentialkaos/ek.svg?branch=develop)](https://travis-ci.org/essentialkaos/ek) | - |
 
 ### License
 

--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,7 @@ go get -u pkg.re/essentialkaos/ek.v3
 |--------|----------|---------|
 | `master` | [![Build Status](https://travis-ci.org/essentialkaos/ek.svg?branch=master)](https://travis-ci.org/essentialkaos/ek) | [![codecov.io](https://codecov.io/github/essentialkaos/ek/coverage.svg?branch=master)](https://codecov.io/github/essentialkaos/ek?branch=master) |
 | `develop` | [![Build Status](https://travis-ci.org/essentialkaos/ek.svg?branch=develop)](https://travis-ci.org/essentialkaos/ek) | [![codecov.io](https://codecov.io/github/essentialkaos/ek/coverage.svg?branch=develop)](https://codecov.io/github/essentialkaos/ek?branch=develop) |
-| `tip` |  [![Build Status](https://travis-ci.org/essentialkaos/ek.svg?branch=develop)](https://travis-ci.org/essentialkaos/ek) | - |
+| `tip` |  [![Build Status](https://travis-ci.org/essentialkaos/ek.svg?branch=tip)](https://travis-ci.org/essentialkaos/ek) | - |
 
 ### License
 

--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/GeertJohan/go.linenoise"
+	"pkg.re/essentialkaos/go-linenoise"
 
 	"pkg.re/essentialkaos/ek.v3/fmtc"
 )

--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -117,7 +117,7 @@ func SetCompletionHandler(h func(input string) []string) {
 
 // SetHintHandler add function for input hints
 func SetHintHandler(h func(input string) string) {
-	linenoise.SetCompletionHandler(h)
+	linenoise.SetHintHandler(h)
 }
 
 // ////////////////////////////////////////////////////////////////////////////////// //

--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -22,8 +22,8 @@ import (
 
 // ////////////////////////////////////////////////////////////////////////////////// //
 
-// KillSignalError is error type when user cancel input
-var KillSignalError = linenoise.KillSignalError
+// ErrKillSignal is error type when user cancel input
+var ErrKillSignal = linenoise.ErrKillSignal
 
 // Prompt is prompt string
 var Prompt = "> "

--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -111,8 +111,13 @@ func AddHistory(data string) {
 }
 
 // SetCompletionHandler add function for autocompletion
-func SetCompletionHandler(compfunc func(in string) []string) {
-	linenoise.SetCompletionHandler(compfunc)
+func SetCompletionHandler(h func(input string) []string) {
+	linenoise.SetCompletionHandler(h)
+}
+
+// SetHintHandler add function for input hints
+func SetHintHandler(h func(input string) string) {
+	linenoise.SetCompletionHandler(h)
 }
 
 // ////////////////////////////////////////////////////////////////////////////////// //

--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"pkg.re/essentialkaos/go-linenoise"
+	"pkg.re/essentialkaos/go-linenoise.v2"
 
 	"pkg.re/essentialkaos/ek.v3/fmtc"
 )

--- a/tmp/tmp.go
+++ b/tmp/tmp.go
@@ -31,6 +31,12 @@ type Temp struct {
 // Dir is default temporary directory
 var Dir = "/tmp"
 
+// DefaultDirPerms is default permissions for directories
+var DefaultDirPerms os.FileMode = 0750
+
+// DefaultFilePerms is default permissions for files
+var DefaultFilePerms os.FileMode = 0640
+
 // ////////////////////////////////////////////////////////////////////////////////// //
 
 // NewTemp create new Temp structure
@@ -67,7 +73,7 @@ func (t *Temp) MkDir(args ...string) (string, error) {
 	}
 
 	tmpDir := getTempName(t.Dir, name)
-	err := os.MkdirAll(tmpDir, 0750)
+	err := os.MkdirAll(tmpDir, DefaultDirPerms)
 
 	if err != nil {
 		return "", err
@@ -87,7 +93,7 @@ func (t *Temp) MkFile(args ...string) (*os.File, string, error) {
 	}
 
 	tmpFile := getTempName(t.Dir, name)
-	fd, err := os.OpenFile(tmpFile, os.O_RDWR|os.O_CREATE, 0640)
+	fd, err := os.OpenFile(tmpFile, os.O_RDWR|os.O_CREATE, DefaultFilePerms)
 
 	if err != nil {
 		return nil, "", err

--- a/tmp/tmp.go
+++ b/tmp/tmp.go
@@ -66,6 +66,10 @@ func NewTemp(args ...string) (*Temp, error) {
 
 // MkDir make temporary directory
 func (t *Temp) MkDir(args ...string) (string, error) {
+	if t == nil {
+		return "", fmt.Errorf("Temp struct is nil")
+	}
+
 	name := ""
 
 	if len(args) != 0 {
@@ -86,6 +90,10 @@ func (t *Temp) MkDir(args ...string) (string, error) {
 
 // MkFile make temporary file
 func (t *Temp) MkFile(args ...string) (*os.File, string, error) {
+	if t == nil {
+		return nil, "", fmt.Errorf("Temp struct is nil")
+	}
+
 	name := ""
 
 	if len(args) != 0 {
@@ -120,7 +128,7 @@ func (t *Temp) MkName(args ...string) string {
 
 // Clean remove all temporary targets
 func (t *Temp) Clean() {
-	if t.targets == nil || len(t.targets) == 0 {
+	if t == nil || t.targets == nil || len(t.targets) == 0 {
 		return
 	}
 

--- a/tmp/tmp_test.go
+++ b/tmp/tmp_test.go
@@ -76,6 +76,16 @@ func (ts *TmpSuite) TestErrors(c *C) {
 	c.Assert(tmpFd, IsNil)
 	c.Assert(tmpFile, Equals, "")
 	c.Assert(err, NotNil)
+
+	var nilTemp *Temp
+
+	_, err = nilTemp.MkDir()
+
+	c.Assert(err, NotNil)
+
+	_, _, err = nilTemp.MkFile()
+
+	c.Assert(err, NotNil)
 }
 
 func (ts *TmpSuite) TestMkDir(c *C) {

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -268,7 +268,7 @@ func renderOptions(options []option, color string) {
 
 		if len(opt.args) != 0 {
 			fmtc.Printf(
-				"  {"+color+"}%s{!} {s}%s{!} %s %s\n",
+				"  {"+color+"}%s{!} {s-}%s{!} %s %s\n",
 				opt.name,
 				opt.args,
 				getOptionSpaces(opt, maxSize),
@@ -295,7 +295,7 @@ func renderExamples(info *Info) {
 		fmtc.Printf("  %s %s\n", info.name, example.cmd)
 
 		if example.desc != "" {
-			fmtc.Printf("  {s}%s{!}\n", example.desc)
+			fmtc.Printf("  {s-}%s{!}\n", example.desc)
 		}
 
 		if index < total-1 {


### PR DESCRIPTION
#### New Features
* `[terminal]` Added hints support from new version of `go-linenoise` :fire: 
* `[fmtc]` Light colors tag (`-`) support :fire:

#### Improvements
* `[terminal]` Using forked [go.linenoise](https://github.com/essentialkaos/go-linenoise) package instead original
* `[fmtc]` Changed colors for `{s}` and `{S}` tags from light grey to dark grey
* `[usage]` Using dark grey color for option values and example description
* `[tmp]` Added `DefaultDirPerms` and `DefaultFilePerms` global variables for permissions customization