### PR TITLE
Version 3.5.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 * `[usage]` Using dark grey color for license and copyright
 * `[fmtutil]` Added global variable `SeparatorColorTag` for separator color customization
+* `[fmtutil]` Added global variable `SeparatorTitleColorTag` for separator title color customization
 
 #### v3.5.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 #### v3.5.1
 
 * `[usage]` Using dark grey color for license and copyright
+* `[fmtutil]` Added global variable `SeparatorColorTag` for separator color customization
 
 #### v3.5.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+#### v3.5.1
+
+* `[usage]` Using dark grey color for license and copyright
+
 #### v3.5.0
 
 * `[terminal]` Using forked [go.linenoise](https://github.com/essentialkaos/go-linenoise) package instead original

--- a/fmtutil/separator.go
+++ b/fmtutil/separator.go
@@ -17,28 +17,26 @@ const _SEPARATOR = "------------------------------------------------------------
 
 // ////////////////////////////////////////////////////////////////////////////////// //
 
-// SeparatorColorTag is color tag used for separator output (light grey by default)
+// SeparatorColorTag is fmtc color tag used for separator (light grey by default)
 var SeparatorColorTag string = "{s}"
+
+// SeparatorTitleColorTag is fmtc color tag used for separator title (light grey by default)
+var SeparatorTitleColorTag = "{s}"
 
 // ////////////////////////////////////////////////////////////////////////////////// //
 
 // Separator print separator to output
 func Separator(tiny bool, args ...string) {
-	var sep = _SEPARATOR
+	sep := SeparatorColorTag + _SEPARATOR + "{!}"
 
 	if len(args) != 0 {
 		name := args[0]
-
-		sep = "-- "
-		sep += name
-		sep += " "
-		sep += _SEPARATOR[0:(84 - len(name))]
+		sep = SeparatorColorTag + "-- {!}" + SeparatorTitleColorTag + name + "{!} " + SeparatorColorTag + _SEPARATOR[:(84-len(name))] + "{!}"
 	}
 
-	switch tiny {
-	case true:
-		fmtc.Printf(SeparatorColorTag+"%s{!}\n", sep)
-	case false:
-		fmtc.Printf("\n"+SeparatorColorTag+"%s{!}\n\n", sep)
+	if !tiny {
+		sep = "\n" + sep + "\n"
 	}
+
+	fmtc.Println(sep)
 }

--- a/fmtutil/separator.go
+++ b/fmtutil/separator.go
@@ -17,6 +17,11 @@ const _SEPARATOR = "------------------------------------------------------------
 
 // ////////////////////////////////////////////////////////////////////////////////// //
 
+// SeparatorColorTag is color tag used for separator output (light grey by default)
+var SeparatorColorTag string = "{s}"
+
+// ////////////////////////////////////////////////////////////////////////////////// //
+
 // Separator print separator to output
 func Separator(tiny bool, args ...string) {
 	var sep = _SEPARATOR
@@ -32,9 +37,8 @@ func Separator(tiny bool, args ...string) {
 
 	switch tiny {
 	case true:
-		fmtc.Printf("{s}%s{!}\n", sep)
+		fmtc.Printf(SeparatorColorTag+"%s{!}\n", sep)
 	case false:
-		fmtc.Printf("\n{s}%s{!}\n\n", sep)
+		fmtc.Printf("\n"+SeparatorColorTag+"%s{!}\n\n", sep)
 	}
-
 }

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -190,17 +190,17 @@ func (about *About) Render() {
 
 	if about.Owner != "" {
 		if about.Year == 0 {
-			fmtc.Printf("{s}Copyright (C) %s{!}\n", about.Owner)
+			fmtc.Printf("{s-}Copyright (C) %s{!}\n", about.Owner)
 		} else {
 			fmtc.Printf(
-				"{s}Copyright (C) %d-%d %s{!}\n",
+				"{s-}Copyright (C) %d-%d %s{!}\n",
 				about.Year, time.Now().Year(), about.Owner,
 			)
 		}
 	}
 
 	if about.License != "" {
-		fmtc.Printf("{s}%s{!}\n", about.License)
+		fmtc.Printf("{s-}%s{!}\n", about.License)
 	}
 
 	fmtc.NewLine()


### PR DESCRIPTION
#### Improvements
* `[usage]` Using dark grey color for license and copyright
* `[fmtutil]` Added global variable `SeparatorColorTag` for separator color customization
* `[fmtutil]` Added global variable `SeparatorTitleColorTag` for separator title color customization
