### PR TITLE
Version 5.4.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+#### v5.3.1
+
+* `[usage]` Changed color for arguments from dark grey to light grey
+
 #### v5.3.0
 
 * `[fmtutil]` Added method `ColorizePassword` for password colorization

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 * `[usage]` Changed color for arguments from dark grey to light grey
 * `[usage]` Added breadcrumbs output for commands and options
+* `[fmtutil]` Fixed special symbols colorization in `ColorizePassword`
 
 #### v5.3.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,9 @@
 ## Changelog
 
-#### v5.3.1
+#### v5.4.0
 
 * `[usage]` Changed color for arguments from dark grey to light grey
+* `[usage]` Added breadcrumbs output for commands and options
 
 #### v5.3.0
 

--- a/fmtutil/fmtutil.go
+++ b/fmtutil/fmtutil.go
@@ -188,7 +188,7 @@ func ColorizePassword(password, letterTag, numTag, specialTag string) string {
 		switch {
 		case r >= 48 && r <= 57:
 			curTag = numTag
-		case r >= 91 && r <= 93:
+		case r >= 91 && r <= 96:
 			curTag = specialTag
 		case r >= 65 && r <= 122:
 			curTag = letterTag

--- a/fmtutil/fmtutil_test.go
+++ b/fmtutil/fmtutil_test.go
@@ -131,13 +131,13 @@ func (s *FmtUtilSuite) TestSeparator(c *C) {
 func (s *FmtUtilSuite) TestColorizePassword(c *C) {
 	p1 := "acbdabcd"
 	p2 := "ABcd12AB"
-	p3 := "AB[3a=c+"
+	p3 := "AB[3a=c_"
 
 	c.Assert(ColorizePassword(p1, "{r}", "{g}", "{y}"), Equals, "{r}acbdabcd{!}")
 	c.Assert(ColorizePassword(p2, "{r}", "{g}", "{y}"), Equals, "{r}ABcd{g}12{r}AB{!}")
-	c.Assert(ColorizePassword(p3, "{r}", "{g}", "{y}"), Equals, "{r}AB{y}[{g}3{r}a{y}={r}c{y}+{!}")
+	c.Assert(ColorizePassword(p3, "{r}", "{g}", "{y}"), Equals, "{r}AB{y}[{g}3{r}a{y}={r}c{y}_{!}")
 
-	c.Assert(ColorizePassword(p3, "{r}", "", ""), Equals, "{r}AB{!}[3{r}a{!}={r}c{!}+{!}")
-	c.Assert(ColorizePassword(p3, "", "{g}", ""), Equals, "{!}AB[{g}3{!}a=c+{!}")
-	c.Assert(ColorizePassword(p3, "", "", "{y}"), Equals, "{!}AB{y}[{!}3a{y}={!}c{y}+{!}")
+	c.Assert(ColorizePassword(p3, "{r}", "", ""), Equals, "{r}AB{!}[3{r}a{!}={r}c{!}_{!}")
+	c.Assert(ColorizePassword(p3, "", "{g}", ""), Equals, "{!}AB[{g}3{!}a=c_{!}")
+	c.Assert(ColorizePassword(p3, "", "", "{y}"), Equals, "{!}AB{y}[{!}3a{y}={!}c{y}_{!}")
 }

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -19,7 +19,12 @@ import (
 
 // ////////////////////////////////////////////////////////////////////////////////// //
 
-const _SPACES = "                                                                "
+const (
+	_SPACES = "                                                                "
+	_DOTS   = "................................................................"
+)
+
+const _BREADCRUMBS_MIN_SIZE = 16
 
 // ////////////////////////////////////////////////////////////////////////////////// //
 
@@ -66,6 +71,9 @@ var (
 
 	// OptionsColor contains default options color
 	OptionsColor = "g"
+
+	// Use bread crumbs for commands and options output
+	Breadcrumbs = false
 )
 
 // ////////////////////////////////////////////////////////////////////////////////// //
@@ -268,18 +276,13 @@ func renderOptions(options []option, color string) {
 
 		if len(opt.args) != 0 {
 			fmtc.Printf(
-				"  {"+color+"}%s{!} {s}%s{!} %s %s\n",
-				opt.name,
-				opt.args,
-				getOptionSpaces(opt, maxSize),
-				fmtc.Sprintf(opt.desc),
+				"  {"+color+"}%s{!} {s}%s{!} "+getBreadcrumbs(opt, maxSize)+" %s\n",
+				opt.name, opt.args, fmtc.Sprintf(opt.desc),
 			)
 		} else {
 			fmtc.Printf(
-				"  {"+color+"}%s{!}  %s %s\n",
-				opt.name,
-				getOptionSpaces(opt, maxSize),
-				fmtc.Sprintf(opt.desc),
+				"  {"+color+"}%s{!} "+getBreadcrumbs(opt, maxSize+1)+" %s\n",
+				opt.name, fmtc.Sprintf(opt.desc),
 			)
 		}
 	}
@@ -304,12 +307,16 @@ func renderExamples(info *Info) {
 	}
 }
 
-// getOptionSpaces return spaces for option name aligning
-func getOptionSpaces(opt option, maxSize int) string {
+// getBreadCrumbs return bread crumbs (or spaces if colors are disabled) for
+// option name aligning
+func getBreadcrumbs(opt option, maxSize int) string {
 	optLen := len(opt.name) + len(opt.args)
-	spaces := maxSize - optLen
 
-	return _SPACES[:spaces]
+	if Breadcrumbs && !fmtc.DisableColors && maxSize > _BREADCRUMBS_MIN_SIZE {
+		return "{s-}" + _DOTS[:maxSize-optLen] + "{!}"
+	}
+
+	return _SPACES[:maxSize-optLen]
 }
 
 // getMaxOptionSize return longest option name size

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -268,7 +268,7 @@ func renderOptions(options []option, color string) {
 
 		if len(opt.args) != 0 {
 			fmtc.Printf(
-				"  {"+color+"}%s{!} {s-}%s{!} %s %s\n",
+				"  {"+color+"}%s{!} {s}%s{!} %s %s\n",
 				opt.name,
 				opt.args,
 				getOptionSpaces(opt, maxSize),


### PR DESCRIPTION
#### New Features
* `[usage]` Added breadcrumbs output for commands and options

#### Improvements
* `[usage]` Changed color for arguments from dark grey to light grey

#### Bugfixes
* `[fmtutil]` Fixed special symbols colorization in `ColorizePassword`