### PR TITLE
Version 0.9.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### v9.1.0
+
+* `[version]` Fixed bug with version comparison
+* `[version]` Added method `Int()` which return version as integer
+
 ### v9.0.0
 
 * Package `args` renamed to `options` (_incompatible changes_)

--- a/version/version.go
+++ b/version/version.go
@@ -173,16 +173,8 @@ func (v Version) Equal(version Version) bool {
 
 // Less return true if given version is greater
 func (v Version) Less(version Version) bool {
-	if v.Major() > version.Major() {
-		return false
-	}
-
-	if v.Minor() > version.Minor() {
-		return false
-	}
-
-	if v.Patch() > version.Patch() {
-		return false
+	if v.Int() < version.Int() {
+		return true
 	}
 
 	pr1, pr2 := v.PreRelease(), version.PreRelease()
@@ -191,25 +183,13 @@ func (v Version) Less(version Version) bool {
 		return prereleaseLess(pr1, pr2)
 	}
 
-	if v.slice == version.slice {
-		return false
-	}
-
-	return true
+	return false
 }
 
 // Greater return true if given version is less
 func (v Version) Greater(version Version) bool {
-	if v.Major() < version.Major() {
-		return false
-	}
-
-	if v.Minor() < version.Minor() {
-		return false
-	}
-
-	if v.Patch() < version.Patch() {
-		return false
+	if v.Int() > version.Int() {
+		return true
 	}
 
 	pr1, pr2 := v.PreRelease(), version.PreRelease()
@@ -218,11 +198,7 @@ func (v Version) Greater(version Version) bool {
 		return !prereleaseLess(pr1, pr2)
 	}
 
-	if v.slice == version.slice {
-		return false
-	}
-
-	return true
+	return false
 }
 
 // Contains check is current version contains given version
@@ -248,6 +224,15 @@ func (v Version) Contains(version Version) bool {
 	}
 
 	return false
+}
+
+// String return version as integer
+func (v Version) Int() int {
+	result := v.Major() * 1000000
+	result += v.Minor() * 1000
+	result += v.Patch()
+
+	return result
 }
 
 // String return version as string

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -203,6 +203,7 @@ func (s *VersionSuite) TestComparison(c *C) {
 	c.Assert(P("1.0.1-a5").Less(P("1.0.1-a5")), Equals, false)
 	c.Assert(P("1.11.0").Less(P("1.10.0")), Equals, false)
 	c.Assert(P("1.0.11").Less(P("1.0.10")), Equals, false)
+	c.Assert(P("2.0.0").Less(P("1.1.0")), Equals, false)
 
 	c.Assert(P("1").Greater(P("1")), Equals, false)
 	c.Assert(P("1").Greater(P("1.0")), Equals, false)
@@ -219,6 +220,7 @@ func (s *VersionSuite) TestComparison(c *C) {
 	c.Assert(P("1.0.1-a5").Greater(P("1.0.1-a5")), Equals, false)
 	c.Assert(P("1.10.0").Greater(P("1.11.0")), Equals, false)
 	c.Assert(P("1.0.10").Greater(P("1.0.11")), Equals, false)
+	c.Assert(P("2.0.0").Greater(P("1.1.0")), Equals, true)
 
 	c.Assert(P("1").Contains(P("1")), Equals, true)
 	c.Assert(P("1").Contains(P("1.1")), Equals, true)


### PR DESCRIPTION
#### New Features
* `[version]` Added method `Int()` which return version as integer

#### Bugfixes
* `[version]` Fixed bug with version comparison (#114)