### PR TITLE
Version 9.7.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 9.6.1
+
+* `[fmt]` More info about color tags
+
 ### 9.6.0
 
 * `[system/procname]` Added method `Replace` which replace just one argument in process command

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ### 9.6.1
 
 * `[fmt]` More info about color tags
+* `[knf]` Removing trailing spaces from property values
 
 ### 9.6.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,8 @@
 
 ### 9.6.1
 
-* `[fmt]` More info about color tags
+* `[fmtc]` More docs about color tags
+* `[fmtc]` Added method `NewT` which creates a new struct for working with the temporary output
 * `[knf]` Removing trailing spaces from property values
 
 ### 9.6.0

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-### 9.6.1
+### 9.7.0
 
 * `[fmtc]` More docs about color tags
 * `[fmtc]` Added method `NewT` which creates a new struct for working with the temporary output

--- a/changelog.md
+++ b/changelog.md
@@ -2,8 +2,8 @@
 
 ### 9.7.0
 
-* `[fmtc]` More docs about color tags
 * `[fmtc]` Added method `NewT` which creates a new struct for working with the temporary output
+* `[fmtc]` More docs about color tags
 * `[knf]` Removing trailing spaces from property values
 
 ### 9.6.0

--- a/fmtc/fmtc.go
+++ b/fmtc/fmtc.go
@@ -32,7 +32,8 @@ type T struct {
 
 // ////////////////////////////////////////////////////////////////////////////////// //
 
-var codes = map[rune]int{
+// Codes map tag -> escape code
+var Codes = map[rune]int{
 	// Special
 	'-': -1, // Light colors
 	'!': 0,  // Default
@@ -181,7 +182,7 @@ func tag2ANSI(tag string, clean bool) string {
 	)
 
 	for _, key := range tag {
-		code := codes[key]
+		code := Codes[key]
 
 		switch key {
 		case '-':
@@ -305,7 +306,7 @@ func getSymbols(symbol string, count int) string {
 
 func isValidTag(tag string) bool {
 	for _, r := range tag {
-		_, hasCode := codes[r]
+		_, hasCode := Codes[r]
 
 		if !hasCode {
 			return false

--- a/fmtc/fmtc.go
+++ b/fmtc/fmtc.go
@@ -32,8 +32,8 @@ type T struct {
 
 // ////////////////////////////////////////////////////////////////////////////////// //
 
-// Codes map tag -> escape code
-var Codes = map[rune]int{
+// codes map tag -> escape code
+var codes = map[rune]int{
 	// Special
 	'-': -1, // Light colors
 	'!': 0,  // Default
@@ -76,6 +76,39 @@ var DisableColors = false
 // Println formats using the default formats for its operands and writes to standard
 // output. Spaces are always added between operands and a newline is appended. It
 // returns the number of bytes written and any write error encountered.
+//
+// Supported color codes.
+// Modificators:
+//  - Light colors
+//  ! Default
+//  * Bold
+//  ^ Dim
+//  _ Underline
+//  ~ Blink
+//  @ Reverse
+//
+// Foreground colors:
+//  d Black (Dark)
+//  r Red
+//  g Green
+//  y Yellow
+//  b Blue
+//  m Magenta
+//  c Cyan
+//  s Gray (Smokey)
+//  w White
+//
+// Background colors:
+//  D Black (Dark)
+//  R Red
+//  G Green
+//  Y Yellow
+//  B Blue
+//  M Magenta
+//  C Cyan
+//  S Gray (Smokey)
+//  W White
+//
 func Println(a ...interface{}) (int, error) {
 	applyColors(&a, DisableColors)
 	return fmt.Println(a...)
@@ -83,6 +116,39 @@ func Println(a ...interface{}) (int, error) {
 
 // Printf formats according to a format specifier and writes to standard output. It
 // returns the number of bytes written and any write error encountered.
+//
+// Supported color codes.
+// Modificators:
+//  - Light colors
+//  ! Default
+//  * Bold
+//  ^ Dim
+//  _ Underline
+//  ~ Blink
+//  @ Reverse
+//
+// Foreground colors:
+//  d Black (Dark)
+//  r Red
+//  g Green
+//  y Yellow
+//  b Blue
+//  m Magenta
+//  c Cyan
+//  s Gray (Smokey)
+//  w White
+//
+// Background colors:
+//  D Black (Dark)
+//  R Red
+//  G Green
+//  Y Yellow
+//  B Blue
+//  M Magenta
+//  C Cyan
+//  S Gray (Smokey)
+//  W White
+//
 func Printf(f string, a ...interface{}) (int, error) {
 	return fmt.Printf(searchColors(f, DisableColors), a...)
 }
@@ -182,7 +248,7 @@ func tag2ANSI(tag string, clean bool) string {
 	)
 
 	for _, key := range tag {
-		code := Codes[key]
+		code := codes[key]
 
 		switch key {
 		case '-':
@@ -306,7 +372,7 @@ func getSymbols(symbol string, count int) string {
 
 func isValidTag(tag string) bool {
 	for _, r := range tag {
-		_, hasCode := Codes[r]
+		_, hasCode := codes[r]
 
 		if !hasCode {
 			return false

--- a/fmtc/fmtc.go
+++ b/fmtc/fmtc.go
@@ -25,7 +25,7 @@ const (
 
 // ////////////////////////////////////////////////////////////////////////////////// //
 
-// T is struct can be used for printing temporary messages
+// T is struct can be used for printing temporary output
 type T struct {
 	size int
 }
@@ -72,6 +72,11 @@ var codes = map[rune]int{
 var DisableColors = false
 
 // ////////////////////////////////////////////////////////////////////////////////// //
+
+// NewT create new struct for working with temporary output
+func NewT() *T {
+	return &T{}
+}
 
 // Println formats using the default formats for its operands and writes to standard
 // output. Spaces are always added between operands and a newline is appended. It

--- a/knf/knf.go
+++ b/knf/knf.go
@@ -590,6 +590,7 @@ func parseRecord(data string, config *Config) (string, string) {
 
 	propName = strings.TrimLeft(propName, " \t")
 	propValue = strings.TrimLeft(propValue, " \t")
+	propValue = strings.TrimRight(propValue, " ")
 
 	if strings.Contains(propValue, _MACRO_SYMBOL) {
 		macroses := macroRE.FindAllStringSubmatch(propValue, -1)

--- a/knf/knf_test.go
+++ b/knf/knf_test.go
@@ -23,7 +23,7 @@ const _CONFIG_DATA = `
 test1:      1
             test2:2
 
-		test3: 3
+		test3: 3 
 
 [string]
   test1: test


### PR DESCRIPTION
#### New Features
* `[fmtc]` Added method `NewT` which creates a new struct for working with the temporary output

#### Improvements
* `[fmtc]` More docs about color tags
* `[knf]` Removing trailing spaces from property values
