### PR TITLE
Version 9.7.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 9.7.1
+
+* `[fmtc]` Improved utf8 support in temporary messages
+
 ### 9.7.0
 
 * `[fmtc]` Added method `NewT` which creates a new struct for working with the temporary output

--- a/fmtc/examples_test.go
+++ b/fmtc/examples_test.go
@@ -98,7 +98,8 @@ func ExampleClean() {
 }
 
 func ExampleT_printf() {
-	t := T{}
+	// You should create new T struct for each line
+	t := NewT()
 
 	t.Printf("This is temporary text")
 	t.Printf("This message replace previous message")

--- a/fmtc/fmtc.go
+++ b/fmtc/fmtc.go
@@ -13,6 +13,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+
+	"pkg.re/essentialkaos/ek.v9/strutil"
 )
 
 // ////////////////////////////////////////////////////////////////////////////////// //
@@ -73,7 +75,7 @@ var DisableColors = false
 
 // ////////////////////////////////////////////////////////////////////////////////// //
 
-// NewT create new struct for working with temporary output
+// NewT create new struct for working with temporary output in one line
 func NewT() *T {
 	return &T{}
 }
@@ -222,7 +224,7 @@ func (t *T) Printf(f string, a ...interface{}) (int, error) {
 		fmt.Printf(getSymbols(_CODE_BACKSPACE, t.size) + "\033[0K")
 	}
 
-	t.size = len(fmt.Sprintf(searchColors(f, true), a...))
+	t.size = strutil.Len(fmt.Sprintf(searchColors(f, true), a...))
 
 	return fmt.Printf(searchColors(f, DisableColors), a...)
 }

--- a/fmtc/fmtc_test.go
+++ b/fmtc/fmtc_test.go
@@ -139,7 +139,7 @@ func (s *FormatSuite) TestMethods(c *C) {
 }
 
 func (s *FormatSuite) TestAux(c *C) {
-	t := &T{}
+	t := NewT()
 
 	t.Printf("TEST %s", "OK")
 	t.Printf("TEST %s", "OK")


### PR DESCRIPTION
#### Improvements
* `[fmtc]` Improved utf8 support in temporary messages
