### PR TITLE
Version 9.15.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 * `[strutil]` Added ellipsis suffix customization
 * `[strutil]` Added support of custom separators for `ReadField`
 * `[req]` Closing response body after parsing data
+* `[system]` Fixed bug with parsing `id` command output with empty group names
+* `[system]` Improved `id` and `getent` commands output parsing
 
 ### 9.14.5
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,12 +1,10 @@
 ## Changelog
 
-### 9.15.1
-
-* `[req]` Closing response body after parsing data
 
 ### 9.15.0
 
 * `[strutil]` Added ellipsis suffix customization
+* `[req]` Closing response body after parsing data
 
 ### 9.14.5
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,5 @@
 ## Changelog
 
-
 ### 9.15.0
 
 * `[strutil]` Added ellipsis suffix customization
@@ -8,6 +7,7 @@
 * `[req]` Closing response body after parsing data
 * `[system]` Fixed bug with parsing `id` command output with empty group names
 * `[system]` Improved `id` and `getent` commands output parsing
+* `[system]` Code refactoring
 
 ### 9.14.5
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 * `[strutil]` Added support of custom separators for `ReadField`
 * `[req]` Closing response body after parsing data
 * `[system]` Fixed bug with parsing `id` command output with empty group names
+* `[system]` Fixed bug with calculating transfered bytes on active interfaces
 * `[system]` Improved `id` and `getent` commands output parsing
 * `[system]` Code refactoring
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 9.15.0
+
+* `[strutil]` Added ellipsis suffix customization
+
 ### 9.14.5
 
 * `[terminal]` Fixed bug with empty title output

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 9.15.1
+
+* `[req]` Closing response body after parsing data
+
 ### 9.15.0
 
 * `[strutil]` Added ellipsis suffix customization

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 ### 9.15.0
 
 * `[strutil]` Added ellipsis suffix customization
+* `[strutil]` Added support of custom separators for `ReadField`
 * `[req]` Closing response body after parsing data
 
 ### 9.14.5

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@
 * `[strutil]` Added support of custom separators for `ReadField`
 * `[req]` Closing response body after parsing data
 * `[system]` Fixed bug with parsing `id` command output with empty group names
-* `[system]` Fixed bug with calculating transfered bytes on active interfaces
+* `[system]` Fixed bug with calculating transferred bytes on active interfaces
 * `[system]` Improved `id` and `getent` commands output parsing
 * `[system]` Code refactoring
 

--- a/req/req.go
+++ b/req/req.go
@@ -317,11 +317,13 @@ func (r *Response) Discard() {
 
 // JSON decode json encoded body
 func (r *Response) JSON(v interface{}) error {
+	defer r.Body.Close()
 	return json.NewDecoder(r.Body).Decode(v)
 }
 
 // String read response body as string
 func (r *Response) String() string {
+	defer r.Body.Close()
 	result, _ := ioutil.ReadAll(r.Body)
 	return string(result)
 }

--- a/strutil/example_test.go
+++ b/strutil/example_test.go
@@ -84,8 +84,10 @@ func ExampleFields() {
 }
 
 func ExampleReadField() {
-	fmt.Println(ReadField("Bob    Alice\tJohn Mary", 2))
+	fmt.Println(ReadField("Bob    Alice\tJohn Mary", 2, true))
+	fmt.Println(ReadField("Bob:::Mary:John:", 3, false, ":"))
 
 	// Output:
 	// John
+	// Mary
 }

--- a/strutil/strutil.go
+++ b/strutil/strutil.go
@@ -15,6 +15,11 @@ import (
 
 // ////////////////////////////////////////////////////////////////////////////////// //
 
+// EllipsisSuffix is ellipsis suffix
+var EllipsisSuffix = "..."
+
+// ////////////////////////////////////////////////////////////////////////////////// //
+
 // Concat fast string concatenation
 func Concat(s ...string) string {
 	var buffer bytes.Buffer
@@ -78,7 +83,7 @@ func Ellipsis(s string, maxSize int) string {
 		return s
 	}
 
-	return Substr(s, 0, maxSize-3) + "..."
+	return Substr(s, 0, maxSize-Len(EllipsisSuffix)) + EllipsisSuffix
 }
 
 // Head return n first symbols from given string

--- a/strutil/strutil.go
+++ b/strutil/strutil.go
@@ -20,6 +20,10 @@ var EllipsisSuffix = "..."
 
 // ////////////////////////////////////////////////////////////////////////////////// //
 
+var defaultFieldsSeparators = []string{" \t"}
+
+// ////////////////////////////////////////////////////////////////////////////////// //
+
 // Concat fast string concatenation
 func Concat(s ...string) string {
 	var buffer bytes.Buffer
@@ -178,21 +182,28 @@ SOURCELOOP:
 }
 
 // ReadField read field with given index from data
-func ReadField(data string, index int) string {
+func ReadField(data string, index int, separators ...string) string {
 	if data == "" || index < 0 {
 		return ""
 	}
 
+	if len(separators) == 0 {
+		separators = defaultFieldsSeparators
+	}
+
 	curIndex, startPointer := -1, -1
 
+MAINLOOP:
 	for i, r := range data {
-		if r == ' ' || r == '\t' {
-			if curIndex == index {
-				return data[startPointer:i]
-			}
+		for _, s := range separators[0] {
+			if r == s {
+				if curIndex == index {
+					return data[startPointer:i]
+				}
 
-			startPointer = -1
-			continue
+				startPointer = -1
+				continue MAINLOOP
+			}
 		}
 
 		if startPointer == -1 {

--- a/strutil/strutil.go
+++ b/strutil/strutil.go
@@ -182,7 +182,7 @@ SOURCELOOP:
 }
 
 // ReadField read field with given index from data
-func ReadField(data string, index int, separators ...string) string {
+func ReadField(data string, index int, multiSep bool, separators ...string) string {
 	if data == "" || index < 0 {
 		return ""
 	}
@@ -199,6 +199,12 @@ MAINLOOP:
 			if r == s {
 				if curIndex == index {
 					return data[startPointer:i]
+				}
+
+				if !multiSep {
+					startPointer = i + 1
+					curIndex++
+					continue MAINLOOP
 				}
 
 				startPointer = -1

--- a/strutil/strutil_test.go
+++ b/strutil/strutil_test.go
@@ -129,6 +129,9 @@ func (s *StrUtilSuite) TestReadField(c *C) {
 	c.Assert(ReadField("abc 1234 DEF", 1), Equals, "1234")
 	c.Assert(ReadField("abc 1234 DEF", 2), Equals, "DEF")
 	c.Assert(ReadField("abc 1234 DEF", 3), Equals, "")
+
+	c.Assert(ReadField("abc|1234|DEF", 1, "|"), Equals, "1234")
+	c.Assert(ReadField("abc+1234|DEF", 1, "|+"), Equals, "1234")
 }
 
 func (s *StrUtilSuite) BenchmarkFields(c *C) {

--- a/strutil/strutil_test.go
+++ b/strutil/strutil_test.go
@@ -124,14 +124,15 @@ func (s *StrUtilSuite) TestFields(c *C) {
 }
 
 func (s *StrUtilSuite) TestReadField(c *C) {
-	c.Assert(ReadField("abc 1234 DEF", -1), Equals, "")
-	c.Assert(ReadField("abc 1234 DEF", 0), Equals, "abc")
-	c.Assert(ReadField("abc 1234 DEF", 1), Equals, "1234")
-	c.Assert(ReadField("abc 1234 DEF", 2), Equals, "DEF")
-	c.Assert(ReadField("abc 1234 DEF", 3), Equals, "")
+	c.Assert(ReadField("abc 1234 DEF", -1, true), Equals, "")
+	c.Assert(ReadField("abc 1234 DEF", 0, true), Equals, "abc")
+	c.Assert(ReadField("abc 1234 DEF", 1, true), Equals, "1234")
+	c.Assert(ReadField("abc 1234 DEF", 2, true), Equals, "DEF")
+	c.Assert(ReadField("abc 1234 DEF", 3, true), Equals, "")
 
-	c.Assert(ReadField("abc|1234|DEF", 1, "|"), Equals, "1234")
-	c.Assert(ReadField("abc+1234|DEF", 1, "|+"), Equals, "1234")
+	c.Assert(ReadField("abc|||||1234||DEF", 1, true, "|"), Equals, "1234")
+	c.Assert(ReadField("abc+1234|DEF", 1, true, "|+"), Equals, "1234")
+	c.Assert(ReadField("abc::1234:::DEF:", 5, false, ":"), Equals, "DEF")
 }
 
 func (s *StrUtilSuite) BenchmarkFields(c *C) {
@@ -142,7 +143,7 @@ func (s *StrUtilSuite) BenchmarkFields(c *C) {
 
 func (s *StrUtilSuite) BenchmarkReadField(c *C) {
 	for i := 0; i < c.N; i++ {
-		ReadField("abc 1234 DEF", 2)
+		ReadField("abc 1234 DEF", 2, false)
 	}
 }
 

--- a/system/info.go
+++ b/system/info.go
@@ -174,34 +174,3 @@ func parseInt(v string, errs *errutil.Errors) int {
 
 	return int(value)
 }
-
-// readField read field from data
-func readField(data string, index int) string {
-	if data == "" {
-		return ""
-	}
-
-	curIndex, startPointer := -1, -1
-
-	for i, r := range data {
-		if r == ' ' || r == '\t' {
-			if curIndex == index {
-				return data[startPointer:i]
-			}
-
-			startPointer = -1
-			continue
-		}
-
-		if startPointer == -1 {
-			startPointer = i
-			curIndex++
-		}
-	}
-
-	if index > curIndex {
-		return ""
-	}
-
-	return data[startPointer:]
-}

--- a/system/info_cpu.go
+++ b/system/info_cpu.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"pkg.re/essentialkaos/ek.v9/errutil"
+	"pkg.re/essentialkaos/ek.v9/strutil"
 )
 
 // ////////////////////////////////////////////////////////////////////////////////// //
@@ -90,14 +91,14 @@ func GetCPUStats() (*CPUStats, error) {
 
 		if len(text) > 4 && text[:3] == "cpu" {
 			if text[:4] == "cpu " {
-				stats.User = parseUint(readField(text, 1), errs)
-				stats.Nice = parseUint(readField(text, 2), errs)
-				stats.System = parseUint(readField(text, 3), errs)
-				stats.Idle = parseUint(readField(text, 4), errs)
-				stats.Wait = parseUint(readField(text, 5), errs)
-				stats.IRQ = parseUint(readField(text, 6), errs)
-				stats.SRQ = parseUint(readField(text, 7), errs)
-				stats.Steal = parseUint(readField(text, 8), errs)
+				stats.User = parseUint(strutil.ReadField(text, 1, true), errs)
+				stats.Nice = parseUint(strutil.ReadField(text, 2, true), errs)
+				stats.System = parseUint(strutil.ReadField(text, 3, true), errs)
+				stats.Idle = parseUint(strutil.ReadField(text, 4, true), errs)
+				stats.Wait = parseUint(strutil.ReadField(text, 5, true), errs)
+				stats.IRQ = parseUint(strutil.ReadField(text, 6, true), errs)
+				stats.SRQ = parseUint(strutil.ReadField(text, 7, true), errs)
+				stats.Steal = parseUint(strutil.ReadField(text, 8, true), errs)
 			} else {
 				stats.Count++
 				continue

--- a/system/info_fs.go
+++ b/system/info_fs.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"pkg.re/essentialkaos/ek.v9/errutil"
+	"pkg.re/essentialkaos/ek.v9/strutil"
 )
 
 // ////////////////////////////////////////////////////////////////////////////////// //
@@ -57,9 +58,9 @@ func GetFSInfo() (map[string]*FSInfo, error) {
 			continue
 		}
 
-		device := readField(text, 0)
-		path := readField(text, 1)
-		fsInfo := &FSInfo{Type: readField(text, 2)}
+		device := strutil.ReadField(text, 0, true)
+		path := strutil.ReadField(text, 1, true)
+		fsInfo := &FSInfo{Type: strutil.ReadField(text, 2, true)}
 
 		stats := &syscall.Statfs_t{}
 
@@ -109,7 +110,7 @@ func GetIOStats() (map[string]*IOStats, error) {
 
 	for s.Scan() {
 		text := s.Text()
-		device := readField(text, 2)
+		device := strutil.ReadField(text, 2, true)
 
 		if len(device) > 3 {
 			if device[:3] == "ram" || device[:3] == "loo" {
@@ -119,17 +120,17 @@ func GetIOStats() (map[string]*IOStats, error) {
 
 		ios := &IOStats{}
 
-		ios.ReadComplete = parseUint(readField(text, 3), errs)
-		ios.ReadMerged = parseUint(readField(text, 4), errs)
-		ios.ReadSectors = parseUint(readField(text, 5), errs)
-		ios.ReadMs = parseUint(readField(text, 6), errs)
-		ios.WriteComplete = parseUint(readField(text, 7), errs)
-		ios.WriteMerged = parseUint(readField(text, 8), errs)
-		ios.WriteSectors = parseUint(readField(text, 9), errs)
-		ios.WriteMs = parseUint(readField(text, 10), errs)
-		ios.IOPending = parseUint(readField(text, 11), errs)
-		ios.IOMs = parseUint(readField(text, 12), errs)
-		ios.IOQueueMs = parseUint(readField(text, 13), errs)
+		ios.ReadComplete = parseUint(strutil.ReadField(text, 3, true), errs)
+		ios.ReadMerged = parseUint(strutil.ReadField(text, 4, true), errs)
+		ios.ReadSectors = parseUint(strutil.ReadField(text, 5, true), errs)
+		ios.ReadMs = parseUint(strutil.ReadField(text, 6, true), errs)
+		ios.WriteComplete = parseUint(strutil.ReadField(text, 7, true), errs)
+		ios.WriteMerged = parseUint(strutil.ReadField(text, 8, true), errs)
+		ios.WriteSectors = parseUint(strutil.ReadField(text, 9, true), errs)
+		ios.WriteMs = parseUint(strutil.ReadField(text, 10, true), errs)
+		ios.IOPending = parseUint(strutil.ReadField(text, 11, true), errs)
+		ios.IOMs = parseUint(strutil.ReadField(text, 12, true), errs)
+		ios.IOQueueMs = parseUint(strutil.ReadField(text, 13, true), errs)
 
 		if errs.HasErrors() {
 			return nil, errs.Last()

--- a/system/info_loadavg.go
+++ b/system/info_loadavg.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"pkg.re/essentialkaos/ek.v9/errutil"
+	"pkg.re/essentialkaos/ek.v9/strutil"
 )
 
 // ////////////////////////////////////////////////////////////////////////////////// //
@@ -45,15 +46,15 @@ func GetLA() (*LoadAvg, error) {
 	la := &LoadAvg{}
 	errs := errutil.NewErrors()
 
-	la.Min1 = parseFloat(readField(text, 0), errs)
-	la.Min5 = parseFloat(readField(text, 1), errs)
-	la.Min15 = parseFloat(readField(text, 2), errs)
+	la.Min1 = parseFloat(strutil.ReadField(text, 0, true), errs)
+	la.Min5 = parseFloat(strutil.ReadField(text, 1, true), errs)
+	la.Min15 = parseFloat(strutil.ReadField(text, 2, true), errs)
 
 	if errs.HasErrors() {
 		return nil, errs.Last()
 	}
 
-	procs := readField(text, 3)
+	procs := strutil.ReadField(text, 3, true)
 	delimPosition := strings.IndexRune(procs, '/')
 
 	if delimPosition == -1 {

--- a/system/info_memory.go
+++ b/system/info_memory.go
@@ -15,6 +15,7 @@ import (
 	"os"
 
 	"pkg.re/essentialkaos/ek.v9/errutil"
+	"pkg.re/essentialkaos/ek.v9/strutil"
 )
 
 // ////////////////////////////////////////////////////////////////////////////////// //
@@ -43,29 +44,29 @@ func GetMemInfo() (*MemInfo, error) {
 	for s.Scan() {
 		text := s.Text()
 
-		switch readField(text, 0) {
+		switch strutil.ReadField(text, 0, true) {
 		case "MemTotal:":
-			mem.MemTotal = parseSize(readField(text, 1), errs)
+			mem.MemTotal = parseSize(strutil.ReadField(text, 1, true), errs)
 		case "MemFree:":
-			mem.MemFree = parseSize(readField(text, 1), errs)
+			mem.MemFree = parseSize(strutil.ReadField(text, 1, true), errs)
 		case "Buffers:":
-			mem.Buffers = parseSize(readField(text, 1), errs)
+			mem.Buffers = parseSize(strutil.ReadField(text, 1, true), errs)
 		case "Cached:":
-			mem.Cached = parseSize(readField(text, 1), errs)
+			mem.Cached = parseSize(strutil.ReadField(text, 1, true), errs)
 		case "SwapCached:":
-			mem.SwapCached = parseSize(readField(text, 1), errs)
+			mem.SwapCached = parseSize(strutil.ReadField(text, 1, true), errs)
 		case "Active:":
-			mem.Active = parseSize(readField(text, 1), errs)
+			mem.Active = parseSize(strutil.ReadField(text, 1, true), errs)
 		case "Inactive:":
-			mem.Inactive = parseSize(readField(text, 1), errs)
+			mem.Inactive = parseSize(strutil.ReadField(text, 1, true), errs)
 		case "SwapTotal:":
-			mem.SwapTotal = parseSize(readField(text, 1), errs)
+			mem.SwapTotal = parseSize(strutil.ReadField(text, 1, true), errs)
 		case "SwapFree:":
-			mem.SwapFree = parseSize(readField(text, 1), errs)
+			mem.SwapFree = parseSize(strutil.ReadField(text, 1, true), errs)
 		case "Dirty:":
-			mem.Dirty = parseSize(readField(text, 1), errs)
+			mem.Dirty = parseSize(strutil.ReadField(text, 1, true), errs)
 		case "Slab:":
-			mem.Slab = parseSize(readField(text, 1), errs)
+			mem.Slab = parseSize(strutil.ReadField(text, 1, true), errs)
 		}
 
 		if errs.HasErrors() {

--- a/system/info_net.go
+++ b/system/info_net.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"pkg.re/essentialkaos/ek.v9/errutil"
+	"pkg.re/essentialkaos/ek.v9/strutil"
 )
 
 // ////////////////////////////////////////////////////////////////////////////////// //
@@ -51,12 +52,12 @@ func GetInterfacesInfo() (map[string]*InterfaceInfo, error) {
 
 		ii := &InterfaceInfo{}
 
-		name := strings.TrimRight(readField(text, 0), ":")
+		name := strings.TrimRight(strutil.ReadField(text, 0, true), ":")
 
-		ii.ReceivedBytes = parseUint(readField(text, 1), errs)
-		ii.ReceivedPackets = parseUint(readField(text, 2), errs)
-		ii.TransmittedBytes = parseUint(readField(text, 9), errs)
-		ii.TransmittedPackets = parseUint(readField(text, 10), errs)
+		ii.ReceivedBytes = parseUint(strutil.ReadField(text, 1, true), errs)
+		ii.ReceivedPackets = parseUint(strutil.ReadField(text, 2, true), errs)
+		ii.TransmittedBytes = parseUint(strutil.ReadField(text, 9, true), errs)
+		ii.TransmittedPackets = parseUint(strutil.ReadField(text, 10, true), errs)
 
 		if errs.HasErrors() {
 			return nil, errs.Last()

--- a/system/info_net.go
+++ b/system/info_net.go
@@ -124,7 +124,7 @@ func getActiveInterfacesBytes(is map[string]*InterfaceInfo) (uint64, uint64) {
 	)
 
 	for name, info := range is {
-		if len(name) < 3 || name[0:3] != "eth" {
+		if strings.HasPrefix(name, "lo") || strings.HasPrefix(name, "bond") {
 			continue
 		}
 

--- a/system/info_test.go
+++ b/system/info_test.go
@@ -410,17 +410,6 @@ func (s *SystemSuite) TestUser(c *C) {
 	}
 }
 
-func (s *SystemSuite) TestFieldParser(c *C) {
-	data := "    abc \t\t 123     \t         ABC $"
-
-	c.Assert(readField("", 0), Equals, "")
-	c.Assert(readField(data, 0), Equals, "abc")
-	c.Assert(readField(data, 1), Equals, "123")
-	c.Assert(readField(data, 2), Equals, "ABC")
-	c.Assert(readField(data, 3), Equals, "$")
-	c.Assert(readField(data, 4), Equals, "")
-}
-
 // ////////////////////////////////////////////////////////////////////////////////// //
 
 func (s *SystemSuite) CreateTestFile(c *C, data string) string {

--- a/system/info_test.go
+++ b/system/info_test.go
@@ -364,9 +364,30 @@ func (s *SystemSuite) TestUser(c *C) {
 		c.Assert(uid, Equals, 1234)
 		c.Assert(gid, Equals, 1234)
 
-		_, _, err = getGroupInfo("_UNKNOWN_")
+		groups := extractGroupsInfo("uid=10123(john) gid=10123(john) groups=10123(john),10200(admins),10201(developers)")
 
-		c.Assert(err, NotNil)
+		c.Assert(groups[0].Name, Equals, "john")
+		c.Assert(groups[0].GID, Equals, 10123)
+		c.Assert(groups[2].Name, Equals, "developers")
+		c.Assert(groups[2].GID, Equals, 10201)
+
+		group, err = parseGetentGroupOutput("developers:*:10201:bob,john")
+
+		c.Assert(err, IsNil)
+		c.Assert(group, NotNil)
+		c.Assert(group.Name, Equals, "developers")
+		c.Assert(group.GID, Equals, 10201)
+
+		user, err = parseGetentPasswdOutput("bob:*:10567:10567::/home/bob:/bin/zsh")
+
+		c.Assert(err, IsNil)
+		c.Assert(user, NotNil)
+		c.Assert(user.Name, Equals, "bob")
+		c.Assert(user.UID, Equals, 10567)
+		c.Assert(user.GID, Equals, 10567)
+		c.Assert(user.Comment, Equals, "")
+		c.Assert(user.HomeDir, Equals, "/home/bob")
+		c.Assert(user.Shell, Equals, "/bin/zsh")
 
 		_, err = getOwner("")
 

--- a/system/info_uptime.go
+++ b/system/info_uptime.go
@@ -14,6 +14,8 @@ import (
 	"errors"
 	"os"
 	"strconv"
+
+	"pkg.re/essentialkaos/ek.v9/strutil"
 )
 
 // ////////////////////////////////////////////////////////////////////////////////// //
@@ -36,7 +38,7 @@ func GetUptime() (uint64, error) {
 	r := bufio.NewReader(fd)
 	text, err := r.ReadString('\n')
 
-	uptimeStr := readField(text, 0)
+	uptimeStr := strutil.ReadField(text, 0, true)
 
 	if uptimeStr == "" {
 		return 0, errors.New("Can't parse file " + procUptimeFile)

--- a/system/process/process.go
+++ b/system/process/process.go
@@ -62,34 +62,3 @@ func parseInt(v string, errs *errutil.Errors) int {
 
 	return int(value)
 }
-
-// readField read field from data
-func readField(data string, index int) string {
-	if data == "" {
-		return ""
-	}
-
-	curIndex, startPointer := -1, -1
-
-	for i, r := range data {
-		if r == ' ' || r == '\t' {
-			if curIndex == index {
-				return data[startPointer:i]
-			}
-
-			startPointer = -1
-			continue
-		}
-
-		if startPointer == -1 {
-			startPointer = i
-			curIndex++
-		}
-	}
-
-	if index > curIndex {
-		return ""
-	}
-
-	return data[startPointer:]
-}

--- a/system/process/process_cpu.go
+++ b/system/process/process_cpu.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"pkg.re/essentialkaos/ek.v9/errutil"
+	"pkg.re/essentialkaos/ek.v9/strutil"
 )
 
 // ////////////////////////////////////////////////////////////////////////////////// //
@@ -82,20 +83,20 @@ func GetInfo(pid int) (*ProcInfo, error) {
 	info := &ProcInfo{}
 	errs := errutil.NewErrors()
 
-	info.PID = parseInt(readField(text, 0), errs)
-	info.Comm = readField(text, 1)
-	info.State = readField(text, 2)
-	info.PPID = parseInt(readField(text, 3), errs)
-	info.Session = parseInt(readField(text, 5), errs)
-	info.TTYNR = parseInt(readField(text, 6), errs)
-	info.TPGid = parseInt(readField(text, 7), errs)
-	info.UTime = parseUint(readField(text, 13), errs)
-	info.STime = parseUint(readField(text, 14), errs)
-	info.CUTime = parseUint(readField(text, 15), errs)
-	info.CSTime = parseUint(readField(text, 16), errs)
-	info.Priority = parseInt(readField(text, 17), errs)
-	info.Nice = parseInt(readField(text, 18), errs)
-	info.NumThreads = parseInt(readField(text, 19), errs)
+	info.PID = parseInt(strutil.ReadField(text, 0, true), errs)
+	info.Comm = strutil.ReadField(text, 1, true)
+	info.State = strutil.ReadField(text, 2, true)
+	info.PPID = parseInt(strutil.ReadField(text, 3, true), errs)
+	info.Session = parseInt(strutil.ReadField(text, 5, true), errs)
+	info.TTYNR = parseInt(strutil.ReadField(text, 6, true), errs)
+	info.TPGid = parseInt(strutil.ReadField(text, 7, true), errs)
+	info.UTime = parseUint(strutil.ReadField(text, 13, true), errs)
+	info.STime = parseUint(strutil.ReadField(text, 14, true), errs)
+	info.CUTime = parseUint(strutil.ReadField(text, 15, true), errs)
+	info.CSTime = parseUint(strutil.ReadField(text, 16, true), errs)
+	info.Priority = parseInt(strutil.ReadField(text, 17, true), errs)
+	info.Nice = parseInt(strutil.ReadField(text, 18, true), errs)
+	info.NumThreads = parseInt(strutil.ReadField(text, 19, true), errs)
 
 	if errs.HasErrors() {
 		return nil, errs.Last()

--- a/system/process/process_memory.go
+++ b/system/process/process_memory.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 
 	"pkg.re/essentialkaos/ek.v9/errutil"
+	"pkg.re/essentialkaos/ek.v9/strutil"
 )
 
 // ////////////////////////////////////////////////////////////////////////////////// //
@@ -61,31 +62,31 @@ func GetMemInfo(pid int) (*MemInfo, error) {
 			continue
 		}
 
-		switch readField(text, 0) {
+		switch strutil.ReadField(text, 0, true) {
 		case "VmPeak:":
-			info.VmPeak = parseSize(readField(text, 1), errs)
+			info.VmPeak = parseSize(strutil.ReadField(text, 1, true), errs)
 		case "VmSize:":
-			info.VmSize = parseSize(readField(text, 1), errs)
+			info.VmSize = parseSize(strutil.ReadField(text, 1, true), errs)
 		case "VmLck:":
-			info.VmLck = parseSize(readField(text, 1), errs)
+			info.VmLck = parseSize(strutil.ReadField(text, 1, true), errs)
 		case "VmPin:":
-			info.VmPin = parseSize(readField(text, 1), errs)
+			info.VmPin = parseSize(strutil.ReadField(text, 1, true), errs)
 		case "VmHWM:":
-			info.VmHWM = parseSize(readField(text, 1), errs)
+			info.VmHWM = parseSize(strutil.ReadField(text, 1, true), errs)
 		case "VmRSS:":
-			info.VmRSS = parseSize(readField(text, 1), errs)
+			info.VmRSS = parseSize(strutil.ReadField(text, 1, true), errs)
 		case "VmData:":
-			info.VmData = parseSize(readField(text, 1), errs)
+			info.VmData = parseSize(strutil.ReadField(text, 1, true), errs)
 		case "VmStk:":
-			info.VmStk = parseSize(readField(text, 1), errs)
+			info.VmStk = parseSize(strutil.ReadField(text, 1, true), errs)
 		case "VmExe:":
-			info.VmExe = parseSize(readField(text, 1), errs)
+			info.VmExe = parseSize(strutil.ReadField(text, 1, true), errs)
 		case "VmLib:":
-			info.VmLib = parseSize(readField(text, 1), errs)
+			info.VmLib = parseSize(strutil.ReadField(text, 1, true), errs)
 		case "VmPTE:":
-			info.VmPTE = parseSize(readField(text, 1), errs)
+			info.VmPTE = parseSize(strutil.ReadField(text, 1, true), errs)
 		case "VmSwap:":
-			info.VmSwap = parseSize(readField(text, 1), errs)
+			info.VmSwap = parseSize(strutil.ReadField(text, 1, true), errs)
 		}
 
 		if errs.HasErrors() {


### PR DESCRIPTION
#### New Features
* `[strutil]` Added ellipsis suffix customization
* `[strutil]` Added support of custom separators for `ReadField`

#### Improvements
* `[system]` Improved `id` and `getent` commands output parsing
* `[system]` Code refactoring

#### Bugfixes
* `[req]` Closing response body after parsing data
* `[system]` Fixed bug with parsing `id` command output with empty group names (#148)
* `[system]` Fixed bug with calculating transferred bytes on active interfaces