### PR TITLE
Fix EK options checks with bound and conflict fields

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -571,7 +571,7 @@ func (opts *Options) validate() []error {
 			conflicts := parseOptionsList(v.Conflicts)
 
 			for _, c := range conflicts {
-				if opts.Has(c.Long) {
+				if opts.Has(c.Long) && opts.Has(n) {
 					errorList = append(errorList, OptionError{n, c.Long, ERROR_CONFLICT})
 				}
 			}
@@ -581,7 +581,7 @@ func (opts *Options) validate() []error {
 			bound := parseOptionsList(v.Bound)
 
 			for _, b := range bound {
-				if !opts.Has(b.Long) {
+				if !opts.Has(b.Long) && opts.Has(n) {
 					errorList = append(errorList, OptionError{n, b.Long, ERROR_BOUND_NOT_SET})
 				}
 			}

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -146,6 +146,19 @@ func (s *OptUtilSuite) TestConflicts(c *C) {
 	c.Assert(errs, Not(HasLen), 0)
 	c.Assert(errs[0].(OptionError).Type, Equals, ERROR_CONFLICT)
 	c.Assert(errs[0].Error(), Equals, "Option test1 conflicts with option test2")
+
+	argline = "--test0 xyz"
+
+	optMap = Map{
+		"test0": {},
+		"test1": {Conflicts: "test2"},
+		"test2": {},
+	}
+
+	opts = NewOptions()
+	_, errs = opts.Parse(strings.Split(argline, " "), optMap)
+
+	c.Assert(errs, HasLen, 0)
 }
 
 func (s *OptUtilSuite) TestBound(c *C) {
@@ -162,6 +175,19 @@ func (s *OptUtilSuite) TestBound(c *C) {
 	c.Assert(errs, Not(HasLen), 0)
 	c.Assert(errs[0].(OptionError).Type, Equals, ERROR_BOUND_NOT_SET)
 	c.Assert(errs[0].Error(), Equals, "Option test2 must be defined with option test1")
+
+	argline = "--test0 xyz"
+
+	optMap = Map{
+		"test0": {},
+		"test1": {Bound: "test2"},
+		"test2": {},
+	}
+
+	opts = NewOptions()
+	_, errs = opts.Parse(strings.Split(argline, " "), optMap)
+
+	c.Assert(errs, HasLen, 0)
 }
 
 func (s *OptUtilSuite) TestGetters(c *C) {


### PR DESCRIPTION
### What did I implement:

Patch which fixed a bug that occurs with usage `Bound` and `Conflict` flags in command line with no arguments and options.

### How did I implement it:

I have added one extra check in `validate()` function. In case we do not have bounded or conflicted arguments in our options map, we should not append an error to error list.

### How can you verify it:

1. Declare options map with two options.
2. Link one of them to another by `Bound` of `Conflict` field.
3. Execute program with no arguments.

```
[...]

var optMap = options.Map{
	OPT_SIZELIMIT: {Type: options.STRING, Bound: OPT_KEEPFILES},
	OPT_KEEPFILES: {Type: options.INT, Value: 0},
}

opts, errs := options.Parse(optMap)

if len(errs) != 0 {
    for _, err := range errs {
	fmt.Println(err.Error())
    }
}
```

I expect that program will be successfully finished with no errors, but it does not.

**Is this ready for review?:** Yes 
**Is it a breaking change?:** No
