### PR TITLE
Version 9.17.4

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 9.17.4
+
+* Dependencies now download with initial `go get` command
+
 ### 9.17.3
 
 * `[options]` Fixed bug with using `Bound` or `Conflict` fields for options (thx to @gongled)

--- a/ek.go
+++ b/ek.go
@@ -7,3 +7,16 @@ package ek
 //        Essential Kaos Open Source License <https://essentialkaos.com/ekol>         //
 //                                                                                    //
 // ////////////////////////////////////////////////////////////////////////////////// //
+
+import (
+	"golang.org/x/crypto/bcrypt"
+	"pkg.re/essentialkaos/go-linenoise.v3"
+)
+
+// ////////////////////////////////////////////////////////////////////////////////// //
+
+// worthless is used as dependency fix
+func worthless() {
+	linenoise.Clear()
+	bcrypt.Cost(nil)
+}


### PR DESCRIPTION
#### Improvements
* Dependencies now download with initial `go get` command