### PR TITLE
Version 9.18.0

### DIFF
--- a/.codebeatsettings
+++ b/.codebeatsettings
@@ -1,5 +1,6 @@
 {
   "GOLANG": {
+    "ABC": [15, 25, 50, 70],
     "TOO_MANY_IVARS": [12, 16, 20, 24],
     "TOO_MANY_FUNCTIONS": [50, 70, 90, 120],
     "TOTAL_LOC": [500, 750, 1000, 2000]

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - go: tip
+    - os: osx
 
 env:
   - EK_TEST_PORT=8080

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 9.18.0
+
+* `[fmtc]` Temporary output feature moved from T struct to `TPrintf` and `TPrintln`
+
 ### 9.17.4
 
 * Dependencies now download with initial `go get` command

--- a/fmtc/examples_test.go
+++ b/fmtc/examples_test.go
@@ -97,10 +97,7 @@ func ExampleClean() {
 	// Output: Text
 }
 
-func ExampleT_printf() {
-	// You should create new T struct for each line
-	t := NewT()
-
-	t.Printf("This is temporary text")
-	t.Printf("This message replace previous message")
+func ExampleTprintf() {
+	TPrintf("This is temporary text")
+	TPrintf("This message replace previous message")
 }

--- a/fmtc/fmtc.go
+++ b/fmtc/fmtc.go
@@ -27,11 +27,6 @@ const (
 
 // ////////////////////////////////////////////////////////////////////////////////// //
 
-// T is struct can be used for printing temporary output
-type T struct {
-	size int
-}
-
 // ////////////////////////////////////////////////////////////////////////////////// //
 
 // codes map tag -> escape code
@@ -75,10 +70,10 @@ var DisableColors = false
 
 // ////////////////////////////////////////////////////////////////////////////////// //
 
-// NewT create new struct for working with temporary output in one line
-func NewT() *T {
-	return &T{}
-}
+// tmpSize is size of temporary output
+var tmpSize int
+
+// ////////////////////////////////////////////////////////////////////////////////// //
 
 // Println formats using the default formats for its operands and writes to standard
 // output. Spaces are always added between operands and a newline is appended. It
@@ -218,24 +213,29 @@ func Bell() {
 
 // ////////////////////////////////////////////////////////////////////////////////// //
 
-// Printf remove the previous message (if printed) and print new message
-func (t *T) Printf(f string, a ...interface{}) (int, error) {
-	if t.size != 0 {
-		fmt.Printf(getSymbols(_CODE_BACKSPACE, t.size) + "\033[0K")
+// TPrintf remove the previous message (if printed) and print new message
+func TPrintf(f string, a ...interface{}) (int, error) {
+	if tmpSize != 0 {
+		fmt.Printf(getSymbols(_CODE_BACKSPACE, tmpSize) + "\033[0K")
 	}
 
-	t.size = strutil.Len(fmt.Sprintf(searchColors(f, true), a...))
+	if f == "" && len(a) == 0 {
+		tmpSize = 0
+		return 0, nil
+	}
+
+	tmpSize = strutil.Len(fmt.Sprintf(searchColors(f, true), a...))
 
 	return fmt.Printf(searchColors(f, DisableColors), a...)
 }
 
-// Println remove the previous message (if printed) and print new message
-func (t *T) Println(a ...interface{}) (int, error) {
-	if t.size != 0 {
-		fmt.Printf(getSymbols(_CODE_BACKSPACE, t.size) + "\033[0K")
+// TPrintln remove the previous message (if printed) and print new message
+func TPrintln(a ...interface{}) (int, error) {
+	if tmpSize != 0 {
+		fmt.Printf(getSymbols(_CODE_BACKSPACE, tmpSize) + "\033[0K")
 	}
 
-	t.size = 0
+	tmpSize = 0
 
 	return Println(a...)
 }

--- a/fmtc/fmtc_test.go
+++ b/fmtc/fmtc_test.go
@@ -139,12 +139,11 @@ func (s *FormatSuite) TestMethods(c *C) {
 }
 
 func (s *FormatSuite) TestAux(c *C) {
-	t := NewT()
+	TPrintf("TEST %s", "OK")
+	TPrintf("")
+	TPrintf("TEST %s", "OK")
 
-	t.Printf("TEST %s", "OK")
-	t.Printf("TEST %s", "OK")
-
-	t.Println("TEST OK")
+	TPrintln("TEST OK")
 
 	Bell()
 	NewLine()


### PR DESCRIPTION
#### Improvements
* `[fmtc]` Temporary output feature moved from T struct to `TPrintf` and `TPrintln`


**NOTE:** Due to various degradation of TravisCI OSX infrastructure, the build fails on OSX is allowed for now.