### PR TITLE
Version 9.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### 9.26.2
+
+* `[fmtc]` Fixed bug with parsing `{}` and `{-}` as valid color tags
+* `[fmtc]` Added fuzz testing
+
 ### 9.26.1
 
 * `[fmtutil/table]` Fixed bug with rendering data using not-configured table

--- a/fmtc/fmtc.go
+++ b/fmtc/fmtc.go
@@ -407,6 +407,10 @@ func getSymbols(symbol string, count int) string {
 }
 
 func isValidTag(tag string) bool {
+	if tag == "" || tag == "-" {
+		return false
+	}
+
 	if isValidExtendedTag(tag) {
 		return true
 	}

--- a/fmtc/fmtc_test.go
+++ b/fmtc/fmtc_test.go
@@ -75,6 +75,8 @@ func (s *FormatSuite) TestReset(c *C) {
 
 func (s *FormatSuite) TestParsing(c *C) {
 	c.Assert(Sprint(""), Equals, "")
+	c.Assert(Sprint("{}"), Equals, "{}")
+	c.Assert(Sprint("{-}"), Equals, "{-}")
 	c.Assert(Sprint("W"), Equals, "W")
 	c.Assert(Sprint("{"), Equals, "{")
 	c.Assert(Sprint("{r"), Equals, "{r")

--- a/fmtc/fuzz.go
+++ b/fmtc/fuzz.go
@@ -1,0 +1,15 @@
+// +build gofuzz
+
+package fmtc
+
+// ////////////////////////////////////////////////////////////////////////////////// //
+//                                                                                    //
+//                     Copyright (c) 2009-2018 ESSENTIAL KAOS                         //
+//        Essential Kaos Open Source License <https://essentialkaos.com/ekol>         //
+//                                                                                    //
+// ////////////////////////////////////////////////////////////////////////////////// //
+
+func Fuzz(data []byte) int {
+	Sprint(string(data))
+	return 0
+}


### PR DESCRIPTION
#### Improvements
* `[fmtc]` Added fuzz testing

#### Bugfixes
* `[fmtc]` Fixed bug with parsing `{}` and `{-}` as valid color tags
