### PR TITLE
Version 10.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - go: tip
-    - os: osx
     - os: windows
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,4 @@ before_install:
 
 script:
   - if [[ "$TRAVIS_OS_NAME" =~ (osx|linux) ]] ; then .travis/script.sh 10 ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]] ; then go install ./... ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]] ; then .travis/windows.sh 10 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ branches:
 
 os:
   - linux
+  - windows
   - osx
 
 matrix:
@@ -23,13 +24,15 @@ matrix:
   allow_failures:
     - go: tip
     - os: osx
+    - os: windows
 
 env:
   - EK_TEST_PORT=8080
 
 before_install:
-  - make deps
-  - make deps-test
+  - if [[ "$TRAVIS_OS_NAME" =~ (osx|linux) ]] ; then make deps ; fi
+  - if [[ "$TRAVIS_OS_NAME" =~ (osx|linux) ]] ; then make deps-test ; fi
 
 script:
-  - .travis/script.sh 10
+  - if [[ "$TRAVIS_OS_NAME" =~ (osx|linux) ]] ; then .travis/script.sh 10 ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]] ; then go install ./... ; fi

--- a/.travis/windows.sh
+++ b/.travis/windows.sh
@@ -27,7 +27,8 @@ makeLink() {
 
 # Download required dependencies
 downloadDeps() {
-  go get -v .
+  go get -v pkg.re/essentialkaos/go-linenoise.v3
+  go get -v golang.org/x/crypto/bcrypt
 }
 
 # Check package installation

--- a/.travis/windows.sh
+++ b/.travis/windows.sh
@@ -27,8 +27,7 @@ makeLink() {
 
 # Download required dependencies
 downloadDeps() {
-  git config --global http.https://pkg.re.followRedirects true
-  go get -v golang.org/x/crypto/bcrypt
+  go get -v -d golang.org/x/crypto/bcrypt
 }
 
 # Check package installation

--- a/.travis/windows.sh
+++ b/.travis/windows.sh
@@ -28,7 +28,6 @@ makeLink() {
 # Download required dependencies
 downloadDeps() {
   git config --global http.https://pkg.re.followRedirects true
-  go get -v pkg.re/essentialkaos/go-linenoise.v3
   go get -v golang.org/x/crypto/bcrypt
 }
 

--- a/.travis/windows.sh
+++ b/.travis/windows.sh
@@ -27,6 +27,7 @@ makeLink() {
 
 # Download required dependencies
 downloadDeps() {
+  git config --global http.https://pkg.re.followRedirects true
   go get -v pkg.re/essentialkaos/go-linenoise.v3
   go get -v golang.org/x/crypto/bcrypt
 }

--- a/.travis/windows.sh
+++ b/.travis/windows.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+main() {
+  makeLink "$1"
+  checkInstall
+}
+
+# Create links for pkg.re import paths
+makeLink() {
+  local version="$1"
+  local pkg_dir="pkg.re/essentialkaos/ek.v${version}"
+
+  # TravicCI download last stable version of ek, but it not ok
+  # remove downloaded version for linking with current version for test
+  if [[ -e $GOPATH/src/${pkg_dir} ]] ; then
+    echo "Directory ${pkg_dir} removed"
+    rm -rf $GOPATH/src/${pkg_dir}
+  fi
+
+  mkdir -p $GOPATH/src/pkg.re/essentialkaos
+
+  echo -e "Created link $GOPATH/src/${pkg_dir} → $GOPATH/src/github.com/essentialkaos/ek\n"
+
+  ln -sf $GOPATH/src/github.com/essentialkaos/ek $GOPATH/src/${pkg_dir}
+}
+
+checkInstall() {
+  go install ./...
+  exit $?
+}
+
+########################################################################################
+
+main "$@"

--- a/.travis/windows.sh
+++ b/.travis/windows.sh
@@ -2,6 +2,7 @@
 
 main() {
   makeLink "$1"
+  downloadDeps
   checkInstall
 }
 
@@ -24,6 +25,12 @@ makeLink() {
   ln -sf $GOPATH/src/github.com/essentialkaos/ek $GOPATH/src/${pkg_dir}
 }
 
+# Download required dependencies
+downloadDeps() {
+  go get -v .
+}
+
+# Check package installation
 checkInstall() {
   go install ./...
   exit $?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * `[system]` `FSInfo` now is `FSUsage` (_incompatible changes_)
 * `[system]` `MemInfo` now is `MemUsage` (_incompatible changes_)
 * `[system]` `CPUInfo` now is `CPUUsage` (_incompatible changes_)
+* `[system]` `InterfaceInfo` now is `InterfaceStats` (_incompatible changes_)
 * `[system]` `GetFSInfo()` now is `GetFSUsage()` (_incompatible changes_)
 * `[system]` `GetMemInfo()` now is `GetMemUsage()` (_incompatible changes_)
 * `[system]` `GetCPUInfo()` now is `GetCPUUsage()` (_incompatible changes_)

--- a/system/info.go
+++ b/system/info.go
@@ -117,8 +117,8 @@ type IOStats struct {
 	IOQueueMs     uint64 `json:"io_queue_ms"`    // Weighted time spent doing I/Os (ms)
 }
 
-// InterfaceInfo contains info about network interfaces
-type InterfaceInfo struct {
+// InterfaceStats contains stats about network interfaces usage
+type InterfaceStats struct {
 	ReceivedBytes      uint64 `json:"received_bytes"`
 	ReceivedPackets    uint64 `json:"received_packets"`
 	TransmittedBytes   uint64 `json:"transmitted_bytes"`

--- a/system/info_cpu_linux.go
+++ b/system/info_cpu_linux.go
@@ -51,6 +51,7 @@ func GetCPUUsage(duration time.Duration) (*CPUUsage, error) {
 // It's ok to have so complex method for calculation
 // codebeat:disable[CYCLO]
 
+// CalculateCPUUsage calcualtes CPU usage based on CPUStats
 func CalculateCPUUsage(c1, c2 *CPUStats) *CPUUsage {
 	prevIdle := c1.Idle + c1.Wait
 	idle := c2.Idle + c2.Wait

--- a/system/info_net_linux.go
+++ b/system/info_net_linux.go
@@ -27,7 +27,7 @@ var procNetFile = "/proc/net/dev"
 // ////////////////////////////////////////////////////////////////////////////////// //
 
 // GetInterfacesStats return info about network interfaces
-func GetInterfacesStats() (map[string]*InterfaceInfo, error) {
+func GetInterfacesStats() (map[string]*InterfaceStats, error) {
 	fd, err := os.OpenFile(procNetFile, os.O_RDONLY, 0)
 
 	if err != nil {
@@ -63,7 +63,7 @@ func GetNetworkSpeed(duration time.Duration) (uint64, uint64, error) {
 
 // CalculateNetworkSpeed calculate network input/output speed in bytes per second for
 // all network interfaces
-func CalculateNetworkSpeed(ii1, ii2 map[string]*InterfaceInfo, duration time.Duration) (uint64, uint64) {
+func CalculateNetworkSpeed(ii1, ii2 map[string]*InterfaceStats, duration time.Duration) (uint64, uint64) {
 	if ii1 == nil || ii2 == nil {
 		return 0, 0
 	}
@@ -85,12 +85,12 @@ func CalculateNetworkSpeed(ii1, ii2 map[string]*InterfaceInfo, duration time.Dur
 // codebeat:disable[LOC,ABC]
 
 // parseInterfacesStats parses interfaces stats data
-func parseInterfacesStats(r io.Reader) (map[string]*InterfaceInfo, error) {
+func parseInterfacesStats(r io.Reader) (map[string]*InterfaceStats, error) {
 	var err error
 
 	s := bufio.NewScanner(r)
 
-	stats := make(map[string]*InterfaceInfo)
+	stats := make(map[string]*InterfaceStats)
 
 	for s.Scan() {
 		text := s.Text()
@@ -99,7 +99,7 @@ func parseInterfacesStats(r io.Reader) (map[string]*InterfaceInfo, error) {
 			continue
 		}
 
-		ii := &InterfaceInfo{}
+		ii := &InterfaceStats{}
 
 		name := strings.TrimRight(strutil.ReadField(text, 0, true), ":")
 
@@ -140,7 +140,7 @@ func parseInterfacesStats(r io.Reader) (map[string]*InterfaceInfo, error) {
 // codebeat:enable[LOC,ABC]
 
 // getActiveInterfacesBytes calculate received and transmitted bytes on all interfaces
-func getActiveInterfacesBytes(is map[string]*InterfaceInfo) (uint64, uint64) {
+func getActiveInterfacesBytes(is map[string]*InterfaceStats) (uint64, uint64) {
 	var (
 		received    uint64
 		transmitted uint64

--- a/system/info_test.go
+++ b/system/info_test.go
@@ -278,8 +278,8 @@ func (s *SystemSuite) TestNet(c *C) {
 	c.Assert(err, IsNil)
 
 	in, out := CalculateNetworkSpeed(
-		map[string]*InterfaceInfo{"eth0": {0, 0, 0, 0}},
-		map[string]*InterfaceInfo{"eth0": {0, 0, 0, 0}},
+		map[string]*InterfaceStats{"eth0": {0, 0, 0, 0}},
+		map[string]*InterfaceStats{"eth0": {0, 0, 0, 0}},
 		time.Second,
 	)
 

--- a/system/info_windows.go
+++ b/system/info_windows.go
@@ -25,14 +25,19 @@ func GetLA() (*LoadAvg, error) {
 	return nil, nil
 }
 
-// GetMemInfo return memory info
-func GetMemInfo() (*MemInfo, error) {
+// GetMemUsage return memory usage info
+func GetMemUsage() (*MemUsage, error) {
 	return nil, nil
 }
 
-// GetCPUInfo return info about CPU usage
-func GetCPUInfo() (*CPUInfo, error) {
+// GetCPUUsage return info about CPU usage
+func GetCPUUsage(duration time.Duration) (*CPUUsage, error) {
 	return nil, nil
+}
+
+// CalculateCPUUsage calcualtes CPU usage based on CPUStats
+func CalculateCPUUsage(c1, c2 *CPUStats) *CPUUsage {
+	return nil
 }
 
 // GetCPUStats return basic CPU stats
@@ -40,9 +45,14 @@ func GetCPUStats() (*CPUStats, error) {
 	return nil, nil
 }
 
-// GetFSInfo return info about mounted filesystems
-func GetFSInfo() (map[string]*FSInfo, error) {
-	return map[string]*FSInfo{"/": {}}, nil
+// GetCPUInfo returns slice with info about CPUs
+func GetCPUInfo() ([]*CPUInfo, error) {
+	return nil, nil
+}
+
+// GetFSUsage return info about mounted filesystems
+func GetFSUsage() (map[string]*FSUsage, error) {
+	return map[string]*FSUsage{"/": {}}, nil
 }
 
 // GetIOStats return I/O stats
@@ -55,9 +65,9 @@ func GetSystemInfo() (*SystemInfo, error) {
 	return nil, nil
 }
 
-// GetInterfacesInfo return info about network interfaces
-func GetInterfacesInfo() (map[string]*InterfaceInfo, error) {
-	return map[string]*InterfaceInfo{"eth0": {}}, nil
+// GetInterfacesStats return info about network interfaces
+func GetInterfacesStats() (map[string]*InterfaceStats, error) {
+	return map[string]*InterfaceStats{"eth0": {}}, nil
 }
 
 // GetNetworkSpeed return input/output speed in bytes per second
@@ -67,7 +77,7 @@ func GetNetworkSpeed(duration time.Duration) (uint64, uint64, error) {
 
 // CalculateNetworkSpeed calculate network input/output speed in bytes per second for
 // all network interfaces
-func CalculateNetworkSpeed(ii1, ii2 map[string]*InterfaceInfo, duration time.Duration) (uint64, uint64) {
+func CalculateNetworkSpeed(ii1, ii2 map[string]*InterfaceStats, duration time.Duration) (uint64, uint64) {
 	return 0, 0
 }
 
@@ -77,7 +87,7 @@ func GetIOUtil(duration time.Duration) (map[string]float64, error) {
 }
 
 // CalculateIOUtil calculate IO utilization for all devices
-func CalculateIOUtil(fi1 map[string]*FSInfo, fi2 map[string]*FSInfo, duration time.Duration) map[string]float64 {
+func CalculateIOUtil(io1, io2 map[string]*IOStats, duration time.Duration) map[string]float64 {
 	return map[string]float64{"/": 0}
 }
 


### PR DESCRIPTION
#### New Features
* `[fmtutil/table]` Added global variable `MaxWidth` for configuration of maximum table width
* `[system]` Added method `GetCPUInfo` for fetching info about CPUs from procfs

#### Improvements
* `[system]` `FSInfo` now is `FSUsage` (_incompatible changes_)
* `[system]` `MemInfo` now is `MemUsage` (_incompatible changes_)
* `[system]` `CPUInfo` now is `CPUUsage` (_incompatible changes_)
* `[system]` `InterfaceInfo` now is `InterfaceStats` (_incompatible changes_)
* `[system]` `GetFSInfo()` now is `GetFSUsage()` (_incompatible changes_)
* `[system]` `GetMemInfo()` now is `GetMemUsage()` (_incompatible changes_)
* `[system]` `GetCPUInfo()` now is `GetCPUUsage()` (_incompatible changes_)
* `[system]` `GetInterfacesInfo()` now is `GetInterfacesStats()` (_incompatible changes_)
* `[initsystem]` `HasService()` now is `IsPresent()` (_incompatible changes_)
* `[initsystem]` `IsServiceWorks()` now is `IsWorks()` (_incompatible changes_)
* `[system]` Added fuzz testing
* `[timeutil]` Code refactoring
* `[fmtutil]` Increased code coverage (97.9% → 100.0%)
* `[fmtutil/table]` Increased code coverage (99.4% → 100.0%)
* `[knf]` Increased code coverage (99.6% → 100.0%)
* `[req]` Increased code coverage (97.1% → 100.0%)
* `[pid]` Increased code coverage (97.4% → 100.0%)
* `[system]` Increased code coverage (73.8% → 79.0%)
* Added tests for windows stubs

#### Bugfixes
* `[system]` Fixed bug with parsing CPU stats data (_found by go-fuzz_)
* `[fmtc]` Fixed bug with parsing reset and modification tags (_found by go-fuzz_)
* `[initsystem]` Fixed examples
* `[fmtc]` Fixed examples