### PR TITLE
Version 12.123.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 12.123.2
 
-- `[terminal]` Fixed bug with output messages from `Error` and `Warn` to stdout insted of stderr
+- `[terminal]` Fixed bug with output messages from `Error` and `Warn` to stdout instead of stderr
 
 ### 12.123.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 12.123.2
+
+- `[terminal]` Fixed bug with output messages from `Error` and `Warn` to stdout insted of stderr
+
 ### 12.123.1
 
 - `[support/network]` Sort and deduplicate IPs

--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -65,7 +65,7 @@ func PrintActionStatus(status int) {
 // Error prints error message
 func Error(message any, args ...any) {
 	fmtc.Fprintf(
-		os.Stdout, ErrorColorTag+ErrorPrefix+"%s{!}\n",
+		os.Stderr, ErrorColorTag+ErrorPrefix+"%s{!}\n",
 		formatMessage(message, ErrorPrefix, args),
 	)
 }
@@ -73,7 +73,7 @@ func Error(message any, args ...any) {
 // Warn prints warning message
 func Warn(message any, args ...any) {
 	fmtc.Fprintf(
-		os.Stdout, WarnColorTag+WarnPrefix+"%s{!}\n",
+		os.Stderr, WarnColorTag+WarnPrefix+"%s{!}\n",
 		formatMessage(message, WarnPrefix, args),
 	)
 }


### PR DESCRIPTION
#### Bugfixes
- `[terminal]` Fixed bug with output messages from `Error` and `Warn` to stdout instead of stderr (_introduced in_ `12.117.0` — 4c2bcacc2e335ab4e33187eaf3e969d7c08f7551)